### PR TITLE
Add cfd and cff to copy the Finder path or selection without leaving the current directory

### DIFF
--- a/dot_config/zsh/functions.zsh
+++ b/dot_config/zsh/functions.zsh
@@ -23,6 +23,37 @@ function cdf() { # short for `cdfinder`
 	cd "$(osascript -e 'tell app "Finder" to POSIX path of (insertion location as alias)')";
 }
 
+# Copy the front Finder window's directory to the clipboard, and echo it.
+# Exists because `cdf && pwd | pbcopy && cd -` clobbers $OLDPWD, so a `cd -`
+# toggle between two work dirs starts landing in the Finder dir. This one
+# never cds, so $PWD and $OLDPWD come out untouched. Yes, `cfd` is one
+# transposed keystroke from `cdf`; mnemonic is "copy Finder dir" vs "cd Finder".
+function cfd() {
+	local dir
+	dir="$(osascript -e 'tell app "Finder" to POSIX path of (insertion location as alias)')" || return $?
+	printf '%s' "$dir" | pbcopy && printf '%s\n' "$dir"
+}
+
+# Copy the full path of each item selected in the front Finder window, one per
+# line in Finder's order, and echo them. An empty selection falls back to cfd,
+# and like cfd this never changes directory.
+function cff() { # "copy Finder file(s)"
+	local sel
+	sel="$(osascript \
+		-e 'set out to ""' \
+		-e 'tell application "Finder"' \
+		-e 'repeat with f in (get selection)' \
+		-e 'set out to out & POSIX path of (f as alias) & linefeed' \
+		-e 'end repeat' \
+		-e 'end tell' \
+		-e 'out')" || return $?
+	if [ -z "$sel" ]; then
+		cfd
+		return $?
+	fi
+	printf '%s' "$sel" | pbcopy && printf '%s\n' "$sel"
+}
+
 # Create a data URL from a file
 function dataurl() {
 	local mimeType=$(file -b --mime-type "$1");

--- a/tests/finder-copy.bats
+++ b/tests/finder-copy.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+
+# Tests for cfd and cff (#34): pure-copy Finder path helpers in
+# dot_config/zsh/functions.zsh.
+#
+# Both functions shell out to osascript (to ask Finder for paths) and pbcopy
+# (to set the clipboard). Real runs would need a GUI session and automation
+# permission, so both are stubbed on $PATH. The osascript stub dispatches on
+# the script text it's handed—"insertion location" vs "selection"—and its
+# output comes from env vars each test exports. The pbcopy stub writes its
+# stdin to a file byte for byte, which is what lets the no-trailing-newline
+# criteria be checked for real rather than through a $(...) that would strip
+# the very newline under test.
+#
+# These are zsh functions, so the tests run them through the real zsh: source
+# the functions file, call the function. No other file in the suite touches a
+# .zsh file yet, so this is the precedent.
+
+load 'helpers'
+
+SRC="${BATS_TEST_DIRNAME}/.."
+FUNCS="$SRC/dot_config/zsh/functions.zsh"
+
+# Resolve zsh before setup() narrows PATH to the stub dir. || true because
+# helpers load under errexit.
+REAL_ZSH="$(command -v zsh || true)"
+
+setup() {
+	export STUBS="$BATS_TEST_TMPDIR/stubs"
+	mkdir -p "$STUBS"
+
+	export OSA_LOG="$BATS_TEST_TMPDIR/osascript.log"
+	: >"$OSA_LOG"
+	export PBCOPY_FILE="$BATS_TEST_TMPDIR/clipboard"
+
+	write_stubs
+
+	export PATH="$STUBS:/usr/bin:/bin"
+}
+
+write_stubs() {
+	# Dispatch on the script text, not argv position, so the stub keeps
+	# working if the functions ever switch between one -e and many.
+	cat >"$STUBS/osascript" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$OSA_LOG"
+if [ -n "$STUB_OSA_FAIL" ]; then
+	echo "execution error: Not authorized to send Apple events to Finder. (-1743)" >&2
+	exit 1
+fi
+case "$*" in
+	*"insertion location"*)
+		printf '%s\n' "$STUB_FINDER_DIR"
+		;;
+	*selection*)
+		# Real osascript prints the script result plus a newline; an
+		# empty selection yields an empty result, so a bare newline.
+		printf '%s\n' "$STUB_FINDER_SELECTION"
+		;;
+	*)
+		echo "osascript stub: unrecognised script: $*" >&2
+		exit 64
+		;;
+esac
+STUB
+
+	cat >"$STUBS/pbcopy" <<'STUB'
+#!/usr/bin/env bash
+cat >"$PBCOPY_FILE"
+STUB
+
+	chmod +x "$STUBS/osascript" "$STUBS/pbcopy"
+}
+
+# The clipboard file's exact bytes, with a sentinel appended so command
+# substitution can't strip a trailing newline before we look for one.
+clipboard_bytes() {
+	cat "$PBCOPY_FILE"
+	printf x
+}
+
+@test "finder-copy: cfd copies the front window directory with no trailing newline and echoes it" {
+	export STUB_FINDER_DIR="/Users/example/Projects/demo"
+
+	run "$REAL_ZSH" -c "source '$FUNCS'; cfd"
+
+	[ "$status" -eq 0 ]
+	assert_contains "/Users/example/Projects/demo"
+	[ "$(clipboard_bytes)" = "/Users/example/Projects/demox" ]
+}
+
+@test "finder-copy: cff with one selected item copies its path with no trailing newline" {
+	export STUB_FINDER_SELECTION="/Users/example/Projects/demo/README.md"
+
+	run "$REAL_ZSH" -c "source '$FUNCS'; cff"
+
+	[ "$status" -eq 0 ]
+	assert_contains "/Users/example/Projects/demo/README.md"
+	[ "$(clipboard_bytes)" = "/Users/example/Projects/demo/README.mdx" ]
+}
+
+@test "finder-copy: cff with multiple items copies newline-separated paths in Finder order" {
+	# Deliberately not sorted: order must be Finder's, not lexical.
+	export STUB_FINDER_SELECTION="/Users/example/b.txt
+/Users/example/a.txt"
+
+	run "$REAL_ZSH" -c "source '$FUNCS'; cff"
+
+	[ "$status" -eq 0 ]
+	[ "$(clipboard_bytes)" = "/Users/example/b.txt
+/Users/example/a.txtx" ]
+}
+
+@test "finder-copy: cff with an empty selection copies the window directory like cfd" {
+	export STUB_FINDER_SELECTION=""
+	export STUB_FINDER_DIR="/Users/example/Projects/demo"
+
+	run "$REAL_ZSH" -c "source '$FUNCS'; cff"
+
+	[ "$status" -eq 0 ]
+	assert_contains "/Users/example/Projects/demo"
+	[ "$(clipboard_bytes)" = "/Users/example/Projects/demox" ]
+}
+
+@test "finder-copy: cfd leaves PWD and OLDPWD untouched" {
+	export STUB_FINDER_DIR="/Users/example/Projects/demo"
+	mkdir -p "$BATS_TEST_TMPDIR/dir-a" "$BATS_TEST_TMPDIR/dir-b"
+
+	run "$REAL_ZSH" -c "cd '$BATS_TEST_TMPDIR/dir-a'; cd '$BATS_TEST_TMPDIR/dir-b'; source '$FUNCS'; cfd >/dev/null; print -r -- \"\$PWD|\$OLDPWD\""
+
+	[ "$status" -eq 0 ]
+	assert_contains "$BATS_TEST_TMPDIR/dir-b|$BATS_TEST_TMPDIR/dir-a"
+}
+
+@test "finder-copy: cff leaves PWD and OLDPWD untouched" {
+	export STUB_FINDER_SELECTION="/Users/example/file.txt"
+	mkdir -p "$BATS_TEST_TMPDIR/dir-a" "$BATS_TEST_TMPDIR/dir-b"
+
+	run "$REAL_ZSH" -c "cd '$BATS_TEST_TMPDIR/dir-a'; cd '$BATS_TEST_TMPDIR/dir-b'; source '$FUNCS'; cff >/dev/null; print -r -- \"\$PWD|\$OLDPWD\""
+
+	[ "$status" -eq 0 ]
+	assert_contains "$BATS_TEST_TMPDIR/dir-b|$BATS_TEST_TMPDIR/dir-a"
+}
+
+@test "finder-copy: cfd returns nonzero and leaves the clipboard alone when osascript fails" {
+	export STUB_OSA_FAIL=1
+	printf 'previous clipboard contents' >"$PBCOPY_FILE"
+
+	run "$REAL_ZSH" -c "source '$FUNCS'; cfd"
+
+	[ "$status" -ne 0 ]
+	[ "$(clipboard_bytes)" = "previous clipboard contentsx" ]
+}
+
+@test "finder-copy: cff returns nonzero and leaves the clipboard alone when osascript fails" {
+	export STUB_OSA_FAIL=1
+	printf 'previous clipboard contents' >"$PBCOPY_FILE"
+
+	run "$REAL_ZSH" -c "source '$FUNCS'; cff"
+
+	[ "$status" -ne 0 ]
+	[ "$(clipboard_bytes)" = "previous clipboard contentsx" ]
+}


### PR DESCRIPTION
Closes #34.

Copying the front Finder window's path used to mean `cdf && pwd | pbcopy && cd -`, and the trailing `cd -` rewrites `$OLDPWD`, so a `cd -` toggle between two work dirs quietly starts landing in the Finder directory instead. There was also no one-liner for copying the paths of the current Finder selection.

- `cfd` copies the front window's directory to the clipboard as an absolute POSIX path with no trailing newline, and echoes it.
- `cff` copies the selection, one path per line in Finder's order, and falls back to `cfd` when nothing is selected.

Neither changes directory, and an `osascript` failure returns nonzero before `pbcopy` runs, so the clipboard keeps its previous contents. `cdf` itself is untouched.

`tests/finder-copy.bats` covers every acceptance criterion with `osascript` and `pbcopy` stubbed on `$PATH`—the pbcopy stub captures exact bytes, so the no-trailing-newline assertions check the real payload. It's the suite's first file to exercise a `.zsh` file: it sources the functions in a real zsh and checks `$PWD`/`$OLDPWD` survive. The full suite is green apart from a failure in `tests/install-failures.bats` ("one failure does not stop the rest") that reproduces with this branch's changes stashed, so it predates this PR.