### PR TITLE
Move the display kit to /dev/tty and adopt it across all ten run_ scripts

### DIFF
--- a/.chezmoitemplates/sh-ui.sh
+++ b/.chezmoitemplates/sh-ui.sh
@@ -19,7 +19,8 @@ warn() { printf '  !  %s\n' "$1"; }
 # Callers set their own EXIT trap (they have their own temp files to clear), so the
 # cursor restore lives here rather than in a trap of its own.
 show_cursor() {
-  [ -t 1 ] && printf '\033[?25h'
+  ui_watching || return 0
+  _ui_write "$_UI_SHOW"
   return 0
 }
 
@@ -45,8 +46,8 @@ progress_bar() {
 spin_until() {
   local label=$1 timeout=$2
   shift 2
-  local start=$SECONDS i=0 n
-  if [ ! -t 1 ]; then
+  local start=$SECONDS n
+  if ! ui_watching; then
     say "$label..."
     while ! "$@"; do
       [ $((SECONDS - start)) -lt "$timeout" ] || return 1
@@ -54,21 +55,20 @@ spin_until() {
     done
     return 0
   fi
-  printf '\033[?25l'
   while ! "$@"; do
     if [ $((SECONDS - start)) -ge "$timeout" ]; then
-      printf '\r\033[K\033[?25h'
+      _ui_erase
       return 1
     fi
     n=0
     while [ "$n" -lt 20 ]; do
-      printf '\r  %s  %s  (%s)\033[K' "${SPINNER_FRAMES[i % 10]}" "$label" "$(elapsed $start)"
-      i=$((i + 1))
+      _UI_FRAME=$((${_UI_FRAME:-0} + 1))
+      _ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  $label  ($(elapsed $start))${_UI_SHOW}"
       n=$((n + 1))
       sleep 0.1
     done
   done
-  printf '\r\033[K\033[?25h'
+  _ui_erase
   return 0
 }
 
@@ -77,28 +77,28 @@ spin_until() {
 # log as the truth and fall back to a bare spinner when nothing parses.
 spin_on_log() {
   local pid=$1 label=$2 log=$3
-  local start=$SECONDS i=0 pct phase
-  if [ ! -t 1 ]; then
+  local start=$SECONDS pct phase
+  if ! ui_watching; then
     say "$label..."
     wait "$pid"
     return $?
   fi
-  printf '\033[?25l'
   while kill -0 "$pid" 2>/dev/null; do
     pct=$(tr '\r' '\n' <"$log" 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | tr -d '%')
     pct=${pct%%.*}
     phase=$(tr '\r' '\n' <"$log" 2>/dev/null | grep -oE '^(Downloading|Downloaded|Installing|Preparing|Waiting)' | tail -1)
     [ -n "$phase" ] || phase=$label
+    _UI_FRAME=$((${_UI_FRAME:-0} + 1))
     if [ -n "$pct" ]; then
-      printf '\r  %s  %-12s %s  %3d%%   (%s)\033[K' \
-        "${SPINNER_FRAMES[i % 10]}" "$phase" "$(progress_bar "$pct")" "$pct" "$(elapsed $start)"
+      _ui_write "${_UI_ERASE}${_UI_HIDE}$(printf '  %s  %-12s %s  %3s%%   (%s)' \
+        "$(_ui_glyph)" "$phase" "$(progress_bar "$pct")" "$pct" "$(elapsed $start)")${_UI_SHOW}"
     else
-      printf '\r  %s  %s  (%s)\033[K' "${SPINNER_FRAMES[i % 10]}" "$phase" "$(elapsed $start)"
+      _ui_write "${_UI_ERASE}${_UI_HIDE}$(printf '  %s  %s  (%s)' \
+        "$(_ui_glyph)" "$phase" "$(elapsed $start)")${_UI_SHOW}"
     fi
-    i=$((i + 1))
     sleep 0.1
   done
-  printf '\r\033[K\033[?25h'
+  _ui_erase
   wait "$pid"
 }
 

--- a/.chezmoitemplates/sh-ui.sh
+++ b/.chezmoitemplates/sh-ui.sh
@@ -1,9 +1,11 @@
-# Terminal chrome shared by the before-phase scripts, pulled in with a Go template include
+# Terminal chrome shared by the apply-phase scripts, pulled in with a Go template include
 # the same way the Brewfile is. Don't write that include inside this file: chezmoi parses
 # this as a template too, so it would recurse.
 #
-# Everything here degrades to plain lines without a TTY. chezmoi captures this output and
-# the auto-sync log has to stay greppable, so no escape codes unless someone's watching.
+# Animation goes to /dev/tty, which is the screen and only the screen. Settled summary
+# lines go to stdout, which is what a captured or piped apply keeps. Detection is an open
+# of /dev/tty rather than a test of stdout, because a human watching
+# `chezmoi apply >log 2>&1` still has a terminal while a stdout probe goes blind on them.
 #
 # Targets bash 3.2, which is what /bin/bash is on a factory Mac. The before phase runs
 # ahead of Homebrew, so nothing newer exists yet for anything that includes this.
@@ -98,4 +100,168 @@ spin_on_log() {
   done
   printf '\r\033[K\033[?25h'
   wait "$pid"
+}
+
+# --- step vocabulary -------------------------------------------------------
+#
+# fd 9 is the screen. It is opened once, lazily, by ui_watching.
+
+# Is anyone watching? Answered by opening /dev/tty, not by testing stdout.
+#
+# /dev/tty fails with "Device not configured" wherever the process has no
+# controlling terminal—under setsid, over ssh without a tty, in a cron job—
+# which is exactly the set of venues that want plain lines. A captured apply is
+# deliberately not in that set. Its /dev/tty stays open, so the animation keeps
+# running on the screen while the log stays greppable.
+#
+# The open is guarded because a `set -e` caller must survive a venue with no
+# terminal, and the answer is cached tri-state so the open happens once.
+ui_watching() {
+  [ -n "${NO_COLOR:-}" ] && return 1
+  [ -n "${DOTFILES_NO_PROGRESS:-}" ] && return 1
+  case "${_UI_TTY:-}" in
+  1) return 0 ;;
+  0) return 1 ;;
+  esac
+  # The redirection order matters: `exec 9>/dev/tty 2>/dev/null` applies
+  # 9>/dev/tty first and prints "Device not configured" to the still-live
+  # stderr before the silencer exists, so every plain-venue run would carry a
+  # diagnostic about the terminal it correctly decided it does not have. A
+  # brace group silences the whole thing and still leaves fd 9 open here,
+  # which a subshell would not.
+  if { exec 9>/dev/tty; } 2>/dev/null; then
+    _UI_TTY=1
+    return 0
+  fi
+  _UI_TTY=0
+  return 1
+}
+
+# Escape sequences, decoded once here rather than spelled as backslashes at
+# each call site. _ui_write hands its argument to `printf '%s'`, which does not
+# interpret escapes—and it must not, because labels and details are caller
+# text that a `%b` would happily reinterpret.
+_UI_HIDE=$'\033[?25l'
+_UI_SHOW=$'\033[?25h'
+_UI_ERASE=$'\r\033[K'
+
+# One frame, one write, always ending with the cursor restore.
+#
+# Both redirections on the subshell are load-bearing, and the second one is the
+# surprise. When /dev/tty is open but its writes fail—a closed pty master,
+# which is how that state gets built—bash 3.2 keeps the bytes of the failed
+# `printf >&9` in its stdout buffer and flushes them when the redirection is
+# undone. A subshell alone does not save you. The flush lands on the subshell's
+# own fd 1, which is still the caller's stdout, and the whole animation spills
+# onto the one stream this design exists to keep clean. A capture measured here
+# carried twelve frames of braille and CSI that way. Pointing the subshell's
+# stdout at /dev/null gives those bytes somewhere harmless to go.
+_ui_write() {
+  ( printf '%s' "$1" >&9 ) >/dev/null 2>&1 || true
+  return 0
+}
+
+# Erase the live line. Nothing but the cursor restore may follow a final frame,
+# and no residual frame text may sit behind the erase.
+_ui_erase() {
+  ui_watching || return 0
+  _ui_write "${_UI_ERASE}${_UI_SHOW}"
+  return 0
+}
+
+# A settled line. Two spaces, one glyph, two spaces, then the shared columns—
+# label, detail, elapsed—so ten scripts' worth of these read as one run
+# rather than as a changelog of unrelated tools.
+_ui_settled() {
+  printf '  %s  %-16s %-24s (%s)\n' "$1" "$2" "$3" "$4"
+  return 0
+}
+
+# The current frame glyph.
+#
+# SPINNER_FRAMES unset and SPINNER_FRAMES empty are separate states on bash
+# 3.2—`${#a[@]}` raises `unbound variable` under `set -u` when unset and
+# evaluates to 0 when empty—so both are guarded, in that order. A display
+# with no frames to draw falls back to a character rather than taking the
+# script down with it.
+_UI_FRAME=0
+
+_ui_glyph() {
+  if [ -z "${SPINNER_FRAMES+x}" ]; then
+    printf '*'
+    return 0
+  fi
+  local n=${#SPINNER_FRAMES[@]}
+  if [ "$n" -eq 0 ]; then
+    printf '*'
+    return 0
+  fi
+  printf '%s' "${SPINNER_FRAMES[${_UI_FRAME:-0} % n]}"
+  return 0
+}
+
+# Open a step: remember its label and start time, and put a first frame on the
+# screen. Writes nothing to stdout—a step that has only begun has no outcome
+# to record yet, and a line written now would have to be unwritten later.
+step_begin() {
+  _UI_STEP_LABEL="$1"
+  _UI_STEP_START=$SECONDS
+  ui_watching || return 0
+  _ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  $1${_UI_SHOW}"
+  return 0
+}
+
+# One frame of a running step. Callers drive this from inside their own loop:
+# the scripts here are synchronous, so there is no background job to poll and
+# no state to share between them.
+#
+# The frame index advances whether or not anyone is watching, so a kit that
+# starts drawing partway through a run picks up where the count is rather than
+# restarting on the first glyph every time.
+step_tick() {
+  local n="${1:-}" total="${2:-}" detail="${3:-}" count=''
+  _UI_FRAME=$((${_UI_FRAME:-0} + 1))
+  ui_watching || return 0
+  if [ -n "$n" ] && [ -n "$total" ]; then
+    count="$n/$total "
+  fi
+  _ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  ${_UI_STEP_LABEL:-}  ${count}${detail}${_UI_SHOW}"
+  return 0
+}
+
+_ui_close() {
+  local glyph="$1" label="$2" detail="${3:-}"
+  local start="${_UI_STEP_START:-$SECONDS}"
+  _ui_erase
+  _ui_settled "$glyph" "$label" "$detail" "$(elapsed "$start")"
+  _UI_STEP_LABEL=""
+  return 0
+}
+
+step_ok() { _ui_close '✓' "$1" "${2:-}"; }
+step_warn() { _ui_close '!' "$1" "${2:-}"; }
+step_fail() { _ui_close '✗' "$1" "${2:-}"; }
+
+# Chained from each caller's EXIT trap, which must capture $? into a local as
+# its very first statement and pass it here. Without that the finalizer reads
+# whatever the trap body's own first command returned—and
+# run_once_before_install-prerequisites' trap opens with `rm -f`, which always
+# returns 0, so a failing script would settle its line as a success.
+#
+# Every command is guarded, not just the last. Under `set -e` a trap aborts at
+# its first failing command, and the write to a vanished tty is exactly the
+# command that fails in the venues this exists for, so an unguarded finalizer
+# never reaches its cursor restore. Returning non-zero is its own bug. A trap
+# that fails turns a successful script into an exit 1, which is a display fault
+# changing the exit status.
+ui_finalize() {
+  local st="${1:-0}"
+  case "$st" in
+  '' | *[!0-9]*) st=0 ;;
+  esac
+  if [ -n "${_UI_STEP_LABEL:-}" ] && [ "$st" -ne 0 ]; then
+    step_fail "$_UI_STEP_LABEL" "failed (exit $st)" || true
+  fi
+  show_cursor || true
+  return 0
 }

--- a/.chezmoitemplates/sh-ui.sh
+++ b/.chezmoitemplates/sh-ui.sh
@@ -14,8 +14,13 @@
 # cannot ride on step_tick alone: every adopted script ticks once per item and
 # then sits inside an install for seconds, so a tick-driven frame freezes for
 # exactly as long as the work takes, which is the silence this kit exists to
-# break. One number, change it to taste.
-_UI_TICK_INTERVAL=1
+# break.
+#
+# It has to run well clear of the terminal's cursor blink, around 1 Hz. The
+# blink is the reference motion already on screen, so a spinner at or below it
+# reads as stalled no matter how faithfully it is advancing. 0.1 is the rate
+# the kit's own spin_until has always used.
+_UI_TICK_INTERVAL=0.1
 
 SPINNER_FRAMES=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
 

--- a/.chezmoitemplates/sh-ui.sh
+++ b/.chezmoitemplates/sh-ui.sh
@@ -71,7 +71,8 @@ spin_until() {
     n=0
     while [ "$n" -lt 20 ]; do
       _UI_FRAME=$((${_UI_FRAME:-0} + 1))
-      _ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  $label  ($(elapsed $start))${_UI_SHOW}"
+      _ui_measure
+      _ui_write "${_UI_ERASE}${_UI_HIDE}$(_ui_fit "  $(_ui_glyph)  $label  ($(elapsed $start))" "$_UI_COLS")${_UI_SHOW}"
       n=$((n + 1))
       sleep 0.1
     done
@@ -91,6 +92,7 @@ spin_on_log() {
     wait "$pid"
     return $?
   fi
+  _ui_measure
   while kill -0 "$pid" 2>/dev/null; do
     pct=$(tr '\r' '\n' <"$log" 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | tr -d '%')
     pct=${pct%%.*}
@@ -98,11 +100,11 @@ spin_on_log() {
     [ -n "$phase" ] || phase=$label
     _UI_FRAME=$((${_UI_FRAME:-0} + 1))
     if [ -n "$pct" ]; then
-      _ui_write "${_UI_ERASE}${_UI_HIDE}$(printf '  %s  %-12s %s  %3s%%   (%s)' \
-        "$(_ui_glyph)" "$phase" "$(progress_bar "$pct")" "$pct" "$(elapsed $start)")${_UI_SHOW}"
+      _ui_write "${_UI_ERASE}${_UI_HIDE}$(_ui_fit "$(printf '  %s  %-12s %s  %3s%%   (%s)' \
+        "$(_ui_glyph)" "$phase" "$(progress_bar "$pct")" "$pct" "$(elapsed $start)")" "$_UI_COLS")${_UI_SHOW}"
     else
-      _ui_write "${_UI_ERASE}${_UI_HIDE}$(printf '  %s  %s  (%s)' \
-        "$(_ui_glyph)" "$phase" "$(elapsed $start)")${_UI_SHOW}"
+      _ui_write "${_UI_ERASE}${_UI_HIDE}$(_ui_fit "$(printf '  %s  %s  (%s)' \
+        "$(_ui_glyph)" "$phase" "$(elapsed $start)")" "$_UI_COLS")${_UI_SHOW}"
     fi
     sleep 0.1
   done
@@ -185,6 +187,54 @@ _ui_settled() {
   return 0
 }
 
+# Terminal width, from the terminal itself.
+#
+# `stty size </dev/tty` is the only thing that answers here. No script run by
+# `chezmoi apply` has COLUMNS set or TERM exported, so a kit reading
+# ${COLUMNS:-80} truncates nothing in production while passing any check that
+# sets the variable.
+#
+# Cached into a global rather than returned, because a caller reading it
+# through $( ) runs this in a subshell whose assignment dies with it, and the
+# fork would then happen ten times a second for the length of a download. A
+# terminal resized mid-apply keeps the width it started with, which costs one
+# wrapped line at the moment of the resize.
+_ui_measure() {
+  [ -n "${_UI_COLS:-}" ] && return 0
+  local size cols
+  size=$(stty size </dev/tty 2>/dev/null) || size=''
+  cols=${size##* }
+  # A terminal reporting nothing, or zero columns, is a display fault. It must
+  # not take the script down and must not produce a nonsense width.
+  case "$cols" in
+  '' | *[!0-9]*) cols=80 ;;
+  esac
+  [ "$cols" -ge 20 ] || cols=80
+  _UI_COLS=$cols
+  return 0
+}
+
+# Trim to a display-column budget. A wrapped live line sends the next carriage
+# return back to the wrong row, after which the animation eats the scrollback
+# above it.
+#
+# ${#s} counts characters rather than bytes under a UTF-8 locale, which is what
+# a braille or block glyph needs. Callers pass plain text with no escape
+# sequences in it, so what is counted here is what the terminal renders.
+_ui_fit() {
+  local s="$1" max="$2"
+  if [ "$max" -lt 2 ]; then
+    printf ''
+    return 0
+  fi
+  if [ "${#s}" -le "$max" ]; then
+    printf '%s' "$s"
+    return 0
+  fi
+  printf '%s…' "${s:0:$((max - 1))}"
+  return 0
+}
+
 # The current frame glyph.
 #
 # SPINNER_FRAMES unset and SPINNER_FRAMES empty are separate states on bash
@@ -215,7 +265,8 @@ step_begin() {
   _UI_STEP_LABEL="$1"
   _UI_STEP_START=$SECONDS
   ui_watching || return 0
-  _ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  $1${_UI_SHOW}"
+  _ui_measure
+  _ui_write "${_UI_ERASE}${_UI_HIDE}$(_ui_fit "  $(_ui_glyph)  $1" "$_UI_COLS")${_UI_SHOW}"
   return 0
 }
 
@@ -233,7 +284,8 @@ step_tick() {
   if [ -n "$n" ] && [ -n "$total" ]; then
     count="$n/$total "
   fi
-  _ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  ${_UI_STEP_LABEL:-}  ${count}${detail}${_UI_SHOW}"
+  _ui_measure
+  _ui_write "${_UI_ERASE}${_UI_HIDE}$(_ui_fit "  $(_ui_glyph)  ${_UI_STEP_LABEL:-}  ${count}${detail}" "$_UI_COLS")${_UI_SHOW}"
   return 0
 }
 

--- a/.chezmoitemplates/sh-ui.sh
+++ b/.chezmoitemplates/sh-ui.sh
@@ -10,6 +10,13 @@
 # Targets bash 3.2, which is what /bin/bash is on a factory Mac. The before phase runs
 # ahead of Homebrew, so nothing newer exists yet for anything that includes this.
 
+# How often the live line redraws itself while the caller is blocked. The frame
+# cannot ride on step_tick alone: every adopted script ticks once per item and
+# then sits inside an install for seconds, so a tick-driven frame freezes for
+# exactly as long as the work takes, which is the silence this kit exists to
+# break. One number, change it to taste.
+_UI_TICK_INTERVAL=1
+
 SPINNER_FRAMES=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
 
 say() { printf '  %s\n' "$1"; }
@@ -264,12 +271,56 @@ _ui_glyph() {
 # Open a step: remember its label and start time, and put a first frame on the
 # screen. Writes nothing to stdout—a step that has only begun has no outcome
 # to record yet, and a line written now would have to be unwritten later.
+# The live line's own clock. Forked by step_begin and re-forked by step_tick,
+# because the text between two ticks never changes — only the glyph does — so
+# re-forking once per item is cheaper than a state file both processes read.
+#
+# Exactly one process writes the live line at a time. Two writers interleave
+# mid-escape-sequence and leave the cursor wherever the loser stopped.
+_ui_start_ticker() {
+  ui_watching || return 0
+  [ "${_UI_NO_LIVE:-0}" = 1 ] && return 0
+  local text="$1"
+  (
+    local i="${_UI_FRAME:-0}"
+    while :; do
+      _UI_FRAME=$i
+      _ui_write "${_UI_ERASE}${_UI_HIDE}$(_ui_fit "  $(_ui_glyph)  ${text}" "$_UI_COLS")${_UI_SHOW}"
+      i=$((i + 1))
+      sleep "$_UI_TICK_INTERVAL"
+    done
+  ) &
+  _UI_TICK_PID=$!
+  return 0
+}
+
+# Guarded end to end. A ticker that cannot be signalled is a cosmetic problem;
+# a finalizer that aborts on one is a display fault changing the exit status.
+_ui_stop_ticker() {
+  [ -n "${_UI_TICK_PID:-}" ] || return 0
+  kill "$_UI_TICK_PID" 2>/dev/null || true
+  wait "$_UI_TICK_PID" 2>/dev/null || true
+  _UI_TICK_PID=""
+  return 0
+}
+
 step_begin() {
   _UI_STEP_LABEL="$1"
   _UI_STEP_START=$SECONDS
   ui_watching || return 0
   _ui_measure
-  _ui_write "${_UI_ERASE}${_UI_HIDE}$(_ui_fit "  $(_ui_glyph)  $1" "$_UI_COLS")${_UI_SHOW}"
+  _ui_start_ticker "$1"
+  return 0
+}
+
+# A step that owns a settled line and no live one. The installer needs this:
+# a frame drawn while `brew bundle` holds /dev/tty can erase a cask's sudo
+# prompt, and the apply then blocks forever on something shown for 100ms.
+# Making it a separate entry point keeps that guarantee structural rather than
+# a matter of where the frames happen to land.
+step_begin_quiet() {
+  _UI_STEP_LABEL="$1"
+  _UI_STEP_START=$SECONDS
   return 0
 }
 
@@ -288,13 +339,15 @@ step_tick() {
     count="$n/$total "
   fi
   _ui_measure
-  _ui_write "${_UI_ERASE}${_UI_HIDE}$(_ui_fit "  $(_ui_glyph)  ${_UI_STEP_LABEL:-}  ${count}${detail}" "$_UI_COLS")${_UI_SHOW}"
+  _ui_stop_ticker
+  _ui_start_ticker "${_UI_STEP_LABEL:-}  ${count}${detail}"
   return 0
 }
 
 _ui_close() {
   local glyph="$1" label="$2" detail="${3:-}"
   local start="${_UI_STEP_START:-$SECONDS}"
+  _ui_stop_ticker
   _ui_erase
   _ui_settled "$glyph" "$label" "$detail" "$(elapsed "$start")"
   _UI_STEP_LABEL=""
@@ -322,6 +375,7 @@ ui_finalize() {
   case "$st" in
   '' | *[!0-9]*) st=0 ;;
   esac
+  _ui_stop_ticker || true
   if [ -n "${_UI_STEP_LABEL:-}" ] && [ "$st" -ne 0 ]; then
     step_fail "$_UI_STEP_LABEL" "failed (exit $st)" || true
   fi

--- a/.chezmoitemplates/sh-ui.sh
+++ b/.chezmoitemplates/sh-ui.sh
@@ -30,7 +30,15 @@ elapsed() {
 }
 
 progress_bar() {
-  local pct=$1 width=24 filled i out=''
+  local pct="${1:-0}" width=24 filled i out=''
+  # A percentage that isn't a number is a display fault, and a display fault
+  # must never take the script down. Under `set -u` the arithmetic below reads
+  # a non-numeric argument as a variable name and aborts the whole script with
+  # `unbound variable`, which is how a cosmetic bar stops a package install.
+  case "$pct" in
+  '' | *[!0-9]*) pct=0 ;;
+  esac
+  [ "$pct" -le 100 ] || pct=100
   filled=$((pct * width / 100))
   # Braces are load-bearing: bash 3.2 reads the block glyph's lead byte as part of the
   # variable name in a UTF-8 locale, so bare "$out█" silently truncates every append.

--- a/.chezmoitemplates/sh-ui.sh
+++ b/.chezmoitemplates/sh-ui.sh
@@ -305,8 +305,8 @@ step_ok() { _ui_close '✓' "$1" "${2:-}"; }
 step_warn() { _ui_close '!' "$1" "${2:-}"; }
 step_fail() { _ui_close '✗' "$1" "${2:-}"; }
 
-# Chained from each caller's EXIT trap, which must capture $? into a local as
-# its very first statement and pass it here. Without that the finalizer reads
+# Chained from each caller's EXIT trap, which must capture $? into a variable
+# as the trap body's very first statement and pass it here. Without that the finalizer reads
 # whatever the trap body's own first command returned—and
 # run_once_before_install-prerequisites' trap opens with `rm -f`, which always
 # returns 0, so a failing script would settle its line as a success.

--- a/.chezmoitemplates/sh-ui.sh
+++ b/.chezmoitemplates/sh-ui.sh
@@ -183,7 +183,10 @@ _ui_erase() {
 # label, detail, elapsed—so ten scripts' worth of these read as one run
 # rather than as a changelog of unrelated tools.
 _ui_settled() {
-  printf '  %s  %-16s %-24s (%s)\n' "$1" "$2" "$3" "$4"
+  # Both fields are trimmed as well as padded. %-24s only pads, so one long
+  # detail pushes the elapsed column out of line and ten scripts stop reading
+  # as one run, which is the whole property these columns exist for.
+  printf '  %s  %-16s %-24s (%s)\n' "$1" "$(_ui_fit "$2" 16)" "$(_ui_fit "$3" 24)" "$4"
   return 0
 }
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,57 @@
+# Checking the progress display on a real apply
+
+The suite covers the display kit in every venue a harness can build. It cannot
+build the one where you sit in front of a terminal and watch an apply run, so
+that check is yours. It takes one command and about a minute.
+
+## Run this
+
+In a real terminal, not over ssh without a tty and not through a wrapper:
+
+```bash
+chezmoi apply >/tmp/apply-capture.log 2>&1
+```
+
+Redirect both streams. That puts you in the venue where a display deciding by
+a test of stdout goes blind while you are still watching, so one run exercises
+the detector and the plain-stdout guarantee together.
+
+## Watch for two things while it runs
+
+The terminal should show a single animated line at the bottom, redrawing in
+place, with a settled line left behind for each script as it finishes:
+
+```
+  ✓  age key          already provisioned      (0:00)
+  ✓  packages         Brewfile applied         (2:31)
+  ⢼  vscode ext       12/43 errorlens          (0:19)
+```
+
+When the apply ends, your cursor should be back. If the prompt returns with no
+cursor, the run left the terminal in a state the kit is supposed to prevent, and
+`reset` will fix your shell.
+
+## Then check the capture
+
+```bash
+LC_ALL=C grep -c $'\033' /tmp/apply-capture.log
+```
+
+That prints the number of lines carrying an ESC byte, `0x1b`. It must print
+`0`. Anything else means escape codes reached the log. That is the defect this
+work exists to remove, because a captured apply has to stay greppable and
+animation belongs on `/dev/tty` and nowhere else.
+
+To see the offending bytes if the count is not zero:
+
+```bash
+LC_ALL=C grep -n $'\033' /tmp/apply-capture.log | head
+```
+
+## One caveat about a steady-state apply
+
+An apply with nothing to do returns in under a second and prints almost
+nothing, which tells you very little. The display is worth watching on a run
+where scripts actually execute: a new machine, a brew day, or after a change to
+one of the ten `run_` scripts. Touching any of them re-runs it on the next
+apply, which is the cheapest way to get a real run to watch.

--- a/run_before_provision-age-key.sh.tmpl
+++ b/run_before_provision-age-key.sh.tmpl
@@ -15,15 +15,25 @@
 
 {{ template "sh-ui.sh" . }}
 
-trap show_cursor EXIT
+# $? is read as the trap body's literal first statement. A finalizer that reads
+# it any later gets the status of whatever ran in between, and settles a failed
+# run as a success.
+ui_exit() {
+  ui_st=$?
+  ui_finalize "$ui_st"
+}
+trap ui_exit EXIT
 
 KEY_PATH="{{ joinPath .chezmoi.homeDir ".config" "chezmoi" "key.txt" }}"
 OP_REF="op://Personal/chezmoi age key/key.txt"
 WAIT_TIMEOUT=600
 
 if [ -s "$KEY_PATH" ] && grep -q 'AGE-SECRET-KEY-1' "$KEY_PATH" 2>/dev/null; then
+  step_ok "age key" "already provisioned"
   exit 0
 fi
+
+step_begin "age key"
 
 # brew lands on a non-login shell's PATH only once we add it (prerequisites installed it).
 [ -x /opt/homebrew/bin/brew ] && eval "$(/opt/homebrew/bin/brew shellenv)"
@@ -43,7 +53,8 @@ if ! command -v op >/dev/null 2>&1; then
 fi
 
 if ! command -v op >/dev/null 2>&1; then
-  warn "1Password CLI unavailable. Seed $KEY_PATH by hand, then re-apply."
+  step_warn "age key" "1Password CLI unavailable"
+  say "Seed $KEY_PATH by hand, then re-apply."
   exit 0
 fi
 
@@ -70,10 +81,10 @@ mkdir -p "$(dirname "$KEY_PATH")"
 if key=$(op read "$OP_REF" 2>/dev/null) && [ -n "$key" ]; then
   printf '%s\n' "$key" >"$KEY_PATH"
   chmod 600 "$KEY_PATH"
-  ok "Fetched age key from 1Password into $KEY_PATH."
+  step_ok "age key" "fetched from 1Password"
   say "(Encrypted Claude config deploys on the next apply, once chezmoi re-reads the key.)"
 else
-  warn "Couldn't read the age key from 1Password."
+  step_fail "age key" "1Password would not answer"
   say "Unlock 1Password and turn on its CLI integration (Settings > Developer), then:"
   say "  op read \"$OP_REF\" > \"$KEY_PATH\" && chmod 600 \"$KEY_PATH\" && chezmoi apply"
 fi

--- a/run_once_before_install-prerequisites.sh.tmpl
+++ b/run_once_before_install-prerequisites.sh.tmpl
@@ -61,10 +61,10 @@ install_clt_headless() {
   rm -f "$log"
 
   if [ -z "$label" ]; then
-    warn "Couldn't find Command Line Tools in the software update catalog."
+    step_warn "xcode clt" "not in the update catalog"
     return 1
   fi
-  ok "$label"
+  say "Installer: $label"
 
   # Prime sudo in the foreground. Backgrounding the install is what lets us draw the
   # progress bar, and a background job can't own the terminal to ask for a password.

--- a/run_once_before_install-prerequisites.sh.tmpl
+++ b/run_once_before_install-prerequisites.sh.tmpl
@@ -20,9 +20,13 @@ set -e
 
 CLT_SENTINEL=/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
 
+# $? is read first, before the removal. rm -f always returns 0, so a finalizer
+# reading it afterward would settle a failed run as a success and the first
+# script of a factory Mac's apply would end on a tick.
 cleanup() {
+  ui_st=$?
   rm -f "$CLT_SENTINEL"
-  show_cursor # cursor back, however we exited
+  ui_finalize "$ui_st"
   return 0
 }
 trap cleanup EXIT
@@ -100,8 +104,9 @@ install_clt_gui() {
 }
 
 if have_clt; then
-  ok "Xcode Command Line Tools already installed."
+  step_ok "xcode clt" "already installed"
 else
+  step_begin "xcode clt"
   say "Xcode Command Line Tools are missing. Homebrew and git need them."
 
   # Only ask when someone's there to answer. The auto-sync LaunchAgent must never
@@ -111,7 +116,8 @@ else
     read -r reply || reply=""
     case "$reply" in
       [nN] | [nN][oO])
-        warn "Skipped. Install them with 'xcode-select --install', then re-run 'chezmoi apply'."
+        step_warn "xcode clt" "skipped by request"
+        say "Install them with 'xcode-select --install', then re-run 'chezmoi apply'."
         exit 1
         ;;
     esac
@@ -119,12 +125,12 @@ else
 
   start=$SECONDS
   if install_clt_headless; then
-    ok "Xcode Command Line Tools installed  ($(elapsed $start))"
+    step_ok "xcode clt" "installed"
   elif install_clt_gui; then
-    ok "Xcode Command Line Tools installed  ($(elapsed $start))"
+    step_ok "xcode clt" "installed"
   else
-    warn "Xcode Command Line Tools didn't install."
-    warn "Run 'xcode-select --install' by hand, then re-run 'chezmoi apply'."
+    step_fail "xcode clt" "did not install"
+    say "Run 'xcode-select --install' by hand, then re-run 'chezmoi apply'."
     exit 1
   fi
 fi
@@ -132,12 +138,13 @@ fi
 # --- Homebrew ---------------------------------------------------------------------
 
 if command -v brew &>/dev/null; then
-  ok "Homebrew already installed."
+  step_ok "homebrew" "already installed"
 else
+  step_begin "homebrew"
   say "Installing Homebrew..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   eval "$(/opt/homebrew/bin/brew shellenv)"
-  ok "Homebrew installed."
+  step_ok "homebrew" "installed"
 fi
 
-say "Prerequisites ready."
+step_ok "prerequisites" "ready"

--- a/run_once_before_install-prerequisites.sh.tmpl
+++ b/run_once_before_install-prerequisites.sh.tmpl
@@ -147,4 +147,4 @@ else
   step_ok "homebrew" "installed"
 fi
 
-step_ok "prerequisites" "ready"
+say "Prerequisites ready."

--- a/run_onchange_after_fetch-licensed-fonts.sh.tmpl
+++ b/run_onchange_after_fetch-licensed-fonts.sh.tmpl
@@ -29,6 +29,11 @@ OP_VAULT="Personal"
 # font feature follows: it must never take `chezmoi apply` down with it.
 skip() {
   step_warn "licensed fonts" "$*"
+  # The settled line is trimmed to its column, and these reasons run past it.
+  # "1Password would not authorize (unlock the app and re-run `chezmoi apply`)"
+  # loses everything after the fortieth character, which is where the
+  # instruction lives.
+  say "$*"
   exit 0
 }
 

--- a/run_onchange_after_fetch-licensed-fonts.sh.tmpl
+++ b/run_onchange_after_fetch-licensed-fonts.sh.tmpl
@@ -16,6 +16,8 @@
 
 set -uo pipefail
 
+{{ template "sh-ui.sh" . }}
+
 FONT_DIR="$HOME/Library/Fonts/Licensed"
 # Two accounts are signed in on this machine. Without pinning, `op` may resolve
 # against the work account, where none of these exist.
@@ -26,7 +28,7 @@ OP_VAULT="Personal"
 # script is the one deliberate exception to the fail-loud rule the rest of the
 # font feature follows: it must never take `chezmoi apply` down with it.
 skip() {
-  echo "Licensed fonts: $* — skipping."
+  step_warn "licensed fonts" "$*"
   exit 0
 }
 
@@ -45,14 +47,27 @@ items=$(echo "$manifest" | grep -vE '^\s*(#|$)' || true)
 workdir=$(mktemp -d)
 # Fires on failure too, so a fetch that dies partway doesn't leave licensed font
 # bytes sitting in /tmp.
-trap 'rm -rf "$workdir"' EXIT
+# $? first, before the removal: rm always returns 0, so a finalizer reading it
+# afterward would settle a failed fetch as a success.
+ui_exit() {
+  ui_st=$?
+  rm -rf "$workdir"
+  ui_finalize "$ui_st"
+}
+trap ui_exit EXIT
 
 mkdir -p "$FONT_DIR"
 installed=0
 skipped=0
+font_total=$(printf '%s\n' "$items" | grep -c . || true)
+font_done=0
+
+step_begin "licensed fonts"
 
 while IFS= read -r title; do
   [ -n "$title" ] || continue
+  font_done=$((font_done + 1))
+  step_tick "$font_done" "$font_total" "$title"
   archive="$workdir/item.zip"
 
   # Reading from /dev/null so `op` can't eat the manifest this loop is reading.
@@ -97,4 +112,4 @@ while IFS= read -r title; do
   rm -f "$archive"
 done <<<"$items"
 
-echo "Licensed fonts: $installed installed or updated, $skipped skipped."
+step_ok "licensed fonts" "$installed installed, $skipped skipped"

--- a/run_onchange_after_install-claude-plugins.sh.tmpl
+++ b/run_onchange_after_install-claude-plugins.sh.tmpl
@@ -105,6 +105,7 @@ install_plugin {{ $spec }}
 {{   end -}}
 {{ else -}}
 step_warn "claude plugins" "no chezmoi decryption key"
+exit 0
 {{ end -}}
 # Counted before expanding: bash 3.2 renders an empty array as one empty word, so an
 # unconditional summary would announce a nameless failure on every clean apply.

--- a/run_onchange_after_install-claude-plugins.sh.tmpl
+++ b/run_onchange_after_install-claude-plugins.sh.tmpl
@@ -20,10 +20,24 @@
 
 set -e
 
+{{ template "sh-ui.sh" . }}
+
+# $? is read as the trap body's literal first statement. A finalizer that reads
+# it any later gets the status of whatever ran in between, and settles a failed
+# run as a success.
+ui_exit() {
+  ui_st=$?
+  ui_finalize "$ui_st"
+}
+trap ui_exit EXIT
+
 if ! command -v claude &>/dev/null; then
-  echo "claude CLI not found — skipping plugin install."
+  step_warn "claude plugins" "claude CLI not found"
   exit 0
 fi
+
+plugin_done=0
+step_begin "claude plugins"
 
 # What the CLI turned down. The rendered body below is a flat run of add_marketplace and
 # install_plugin calls rather than a loop, so the accumulator lives out here where both
@@ -37,7 +51,8 @@ add_marketplace() {
   # 2>/dev/null survives on the probe, not on the install: `marketplace list` grumbles on a
   # machine that has none registered yet, and "none yet" is the normal first-run state.
   claude plugin marketplace list 2>/dev/null | grep -q "$name" && return 0
-  echo "Adding marketplace $name ($repo)..."
+  plugin_done=$((plugin_done + 1))
+  step_tick "$plugin_done" "" "marketplace $name"
   if ! claude plugin marketplace add "$repo"; then
     failed+=("marketplace $name ($repo)")
   fi
@@ -46,7 +61,8 @@ add_marketplace() {
 install_plugin() {
   local spec="$1"
   claude plugin list 2>/dev/null | grep -q "${spec%@*}" && return 0
-  echo "Installing $spec..."
+  plugin_done=$((plugin_done + 1))
+  step_tick "$plugin_done" "" "$spec"
   if ! claude plugin install "$spec"; then
     failed+=("plugin $spec")
   fi
@@ -88,15 +104,16 @@ install_plugin {{ $spec }}
 {{     end -}}
 {{   end -}}
 {{ else -}}
-echo "No chezmoi decryption key present — skipping plugin reinstall."
+step_warn "claude plugins" "no chezmoi decryption key"
 {{ end -}}
 # Counted before expanding: bash 3.2 renders an empty array as one empty word, so an
 # unconditional summary would announce a nameless failure on every clean apply.
 if [ "${#failed[@]}" -gt 0 ]; then
+  step_warn "claude plugins" "${#failed[@]} refused"
   echo "The claude CLI ran, but these did not install (its errors are above):"
   printf '  %s\n' "${failed[@]}"
 else
-  echo "Claude Code plugins ready."
+  step_ok "claude plugins" "$plugin_done handled"
 fi
 
 # Exit 0 with failures named. A marketplace that was unreachable for thirty seconds must not

--- a/run_onchange_after_install-global-node-packages.sh.tmpl
+++ b/run_onchange_after_install-global-node-packages.sh.tmpl
@@ -104,4 +104,4 @@ install_globals pnpm "$(cat <<'PNPMEOF'
 PNPMEOF
 )"
 
-step_ok "node globals" "done"
+say "Global node packages installed."

--- a/run_onchange_after_install-global-node-packages.sh.tmpl
+++ b/run_onchange_after_install-global-node-packages.sh.tmpl
@@ -15,13 +15,27 @@
 
 set -e
 
+{{ template "sh-ui.sh" . }}
+
+# $? is read as the trap body's literal first statement. A finalizer that reads
+# it any later gets the status of whatever ran in between, and settles a failed
+# run as a success.
+ui_exit() {
+  ui_st=$?
+  ui_finalize "$ui_st"
+}
+trap ui_exit EXIT
+
 install_globals() {
   local manager="$1"
   local list_content="$2"
   if ! command -v "$manager" &>/dev/null; then
-    echo "$manager not found, skipping global package install."
+    step_warn "$manager -g" "$manager not found"
     return 0
   fi
+  local total done_n=0
+  total=$(printf '%s\n' "$list_content" | grep -cE '^[^#[:space:]]' || true)
+  step_begin "$manager -g"
   local subcommand
   case "$manager" in
     npm)  subcommand="install -g" ;;
@@ -37,12 +51,14 @@ install_globals() {
   set +e
   while IFS= read -r pkg; do
     [[ "$pkg" =~ ^#.*$ || -z "$pkg" ]] && continue
-    echo "  $manager $subcommand $pkg"
+    done_n=$((done_n + 1))
+    step_tick "$done_n" "$total" "$pkg"
     if ! command "$manager" $subcommand "$pkg"; then
       echo "    skipped: '$pkg' failed to install (often an outdated node)"
     fi
   done <<<"$list_content"
   set -e
+  step_ok "$manager -g" "$total packages"
 }
 
 # Ensure a current default node before installing globals. brew installs nvm but no
@@ -74,20 +90,18 @@ if command -v nvm >/dev/null 2>&1; then
     corepack enable pnpm 2>/dev/null || true
   fi
 else
-  echo "nvm not found, skipping node setup and global installs."
+  step_warn "node" "nvm not found"
 fi
 set -e
 
-echo "Installing global npm packages..."
 install_globals npm "$(cat <<'NPMEOF'
 {{ include "dot_config/npm-globals.txt" }}
 NPMEOF
 )"
 
-echo "Installing global pnpm packages..."
 install_globals pnpm "$(cat <<'PNPMEOF'
 {{ include "dot_config/pnpm-globals.txt" }}
 PNPMEOF
 )"
 
-echo "Global node packages installed."
+step_ok "node globals" "done"

--- a/run_onchange_after_load-launchagents.sh.tmpl
+++ b/run_onchange_after_load-launchagents.sh.tmpl
@@ -13,6 +13,17 @@
 # teardown:secret ~/.local/state/dotfiles
 set -e
 
+{{ template "sh-ui.sh" . }}
+
+# $? is read as the trap body's literal first statement. A finalizer that reads
+# it any later gets the status of whatever ran in between, and settles a failed
+# run as a success.
+ui_exit() {
+  ui_st=$?
+  ui_finalize "$ui_st"
+}
+trap ui_exit EXIT
+
 SCHEDULE="{{ $sched }}"
 PLIST="{{ .chezmoi.homeDir }}/Library/LaunchAgents/com.k-arnett.dotfiles-auto-sync.plist"
 LABEL="com.k-arnett.dotfiles-auto-sync"
@@ -24,13 +35,14 @@ launchctl bootout "${TARGET}/${LABEL}" 2>/dev/null || true
 
 if [[ "$SCHEDULE" == "off" ]]; then
   rm -f "$PLIST"
-  echo "Auto-sync off; LaunchAgent unloaded."
+  step_ok "launchagents" "off, agent unloaded"
   exit 0
 fi
 
 if [[ -f "$PLIST" ]]; then
   launchctl bootstrap "$TARGET" "$PLIST"
-  echo "Auto-sync loaded on the '$SCHEDULE' schedule."
+  step_ok "launchagents" "loaded, $SCHEDULE"
 else
-  echo "Schedule is '$SCHEDULE' but no plist at $PLIST; nothing loaded."
+  step_warn "launchagents" "$SCHEDULE, but no plist"
+  say "Expected it at $PLIST."
 fi

--- a/run_onchange_after_restore-agent-skills.sh.tmpl
+++ b/run_onchange_after_restore-agent-skills.sh.tmpl
@@ -13,10 +13,21 @@
 # teardown:secret ~/.config/gh/hosts.yml
 # teardown:data ~/.agents/skills
 
+{{ template "sh-ui.sh" . }}
+
+# $? is read as the trap body's literal first statement. A finalizer that reads
+# it any later gets the status of whatever ran in between, and settles a failed
+# run as a success.
+ui_exit() {
+  ui_st=$?
+  ui_finalize "$ui_st"
+}
+trap ui_exit EXIT
+
 LOCKFILE="{{ joinPath .chezmoi.homeDir ".local" "state" "skills" ".skill-lock.json" }}"
 SKILLS_DIR="{{ joinPath .chezmoi.homeDir ".agents" "skills" }}"
 
-[ -f "$LOCKFILE" ] || { echo "No skill lockfile at $LOCKFILE; nothing to restore."; exit 0; }
+[ -f "$LOCKFILE" ] || { step_warn "agent skills" "no lockfile"; exit 0; }
 
 # node/npx live under nvm, which every run_ script must re-source (PATH doesn't carry over).
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
@@ -30,7 +41,7 @@ command -v nvm >/dev/null 2>&1 && nvm use default >/dev/null 2>&1
 
 for tool in npx jq; do
   if ! command -v "$tool" >/dev/null 2>&1; then
-    echo "$tool not found; skipping skill restore."
+    step_warn "agent skills" "$tool not found"
     exit 0
   fi
 done
@@ -43,11 +54,13 @@ needed=$(jq -r '.skills | to_entries[] | "\(.value.source)\t\(.key)"' "$LOCKFILE
     done)
 
 if [ -z "$needed" ]; then
-  echo "All lockfile skills already installed."
+  step_ok "agent skills" "all present"
   exit 0
 fi
 
-echo "Restoring $(printf '%s\n' "$needed" | wc -l | tr -d ' ') missing agent skill(s)."
+skill_total=$(printf '%s\n' "$needed" | wc -l | tr -d ' ')
+skill_done=0
+step_begin "agent skills"
 
 # The kendrick/* skill repos are private and need GitHub auth to clone. Prompt rather than
 # skip, so the restore comes back complete instead of quietly partial.
@@ -83,8 +96,10 @@ for src in $(printf '%s\n' "$needed" | cut -f1 | sort -u); do
   while IFS= read -r name; do
     s_args+=(-s "$name")
   done < <(printf '%s\n' "$needed" | awk -F'\t' -v s="$src" '$1==s{print $2}')
-  echo "  skills add $src ${a_args[*]} ${s_args[*]}"
+  skill_done=$((skill_done + 1))
+  step_tick "$skill_done" "$skill_total" "$src"
   npx --yes skills add "$src" -g -y "${a_args[@]}" "${s_args[@]}" || echo "    some skills from $src failed (a name may have changed upstream)"
 done
 
-echo "Skill restore done. If you signed into GitHub mid-run, re-run 'chezmoi apply' to pick up any private skills it skipped."
+step_ok "agent skills" "$skill_total restored"
+say "If you signed into GitHub mid-run, re-run 'chezmoi apply' to pick up any private skills it skipped."

--- a/run_onchange_configure-raycast.sh.tmpl
+++ b/run_onchange_configure-raycast.sh.tmpl
@@ -9,14 +9,35 @@
 
 set -e
 
+{{ template "sh-ui.sh" . }}
+
+# $? is read as the trap body's literal first statement. A finalizer that reads
+# it any later gets the status of whatever ran in between, and settles a failed
+# run as a success.
+ui_exit() {
+  ui_st=$?
+  ui_finalize "$ui_st"
+}
+trap ui_exit EXIT
+
 if ! command -v open &>/dev/null; then
   # This branch was a bare `exit 0`. Alone among the four installers it left no trace, so on
   # a non-macOS box the script did not read as skipped — it read as absent.
-  echo "open command not found — skipping Raycast configuration."
+  step_warn "raycast ext" "open not found, skipping Raycast configuration"
   exit 0
 fi
 
-echo "Requesting Raycast extension installs..."
+# Read into a variable before the loop: the live line needs a denominator, and
+# a process substitution gives the loop no way to know how many are coming.
+raycast_exts=$(
+  cat <<'EXTEOF'
+{{ include "dot_config/raycast-extensions.txt" }}
+EXTEOF
+)
+ray_total=$(printf '%s\n' "$raycast_exts" | grep -cE '^[^#[:space:]]' || true)
+ray_done=0
+
+step_begin "raycast ext"
 
 # The ceiling on what this script can honestly report. `open` hands the URL to launchd and
 # returns the moment macOS accepts it, well before Raycast has fetched, built, or rejected
@@ -28,15 +49,15 @@ refused=()
 while IFS= read -r ext; do
   # Skip comments and empty lines
   [[ "$ext" =~ ^#.*$ || -z "$ext" ]] && continue
-  echo "  → $ext"
+  ray_done=$((ray_done + 1))
+  step_tick "$ray_done" "$ray_total" "$ext"
   if ! open "raycast://extensions/install/$ext"; then
     refused+=("$ext")
   fi
   sleep 1
-done < <(cat <<'EXTEOF'
-{{ include "dot_config/raycast-extensions.txt" }}
+done <<EXTEOF
+$raycast_exts
 EXTEOF
-)
 
 # The hotkey write sits between the loop and the summary, and `set -e` is on, so an
 # unwritable domain used to abort the script right here — exiting non-zero over a preference
@@ -50,10 +71,11 @@ fi
 # Guarded on the count: bash 3.2 turns an empty array into one empty word, and a heading
 # with a blank line under it is a failure report nobody can act on.
 if [ "${#refused[@]}" -gt 0 ]; then
+  step_warn "raycast ext" "${#refused[@]} of $ray_total refused"
   echo "macOS would not hand these install URLs to Raycast (its errors are above):"
   printf '  raycast://extensions/install/%s\n' "${refused[@]}"
 else
-  echo "Raycast install requests sent. Raycast picks them up in the background."
+  step_ok "raycast ext" "$ray_total requested"
 fi
 
 # A URL Raycast never received is not grounds for stopping the apply, so: 0.

--- a/run_onchange_configure-raycast.sh.tmpl
+++ b/run_onchange_configure-raycast.sh.tmpl
@@ -23,7 +23,8 @@ trap ui_exit EXIT
 if ! command -v open &>/dev/null; then
   # This branch was a bare `exit 0`. Alone among the four installers it left no trace, so on
   # a non-macOS box the script did not read as skipped — it read as absent.
-  step_warn "raycast ext" "open not found, skipping Raycast configuration"
+  step_warn "raycast ext" "open not found"
+  say "open command not found, skipping Raycast configuration."
   exit 0
 fi
 

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -178,7 +178,7 @@ trap ui_exit EXIT
 # frame landing there can erase a password prompt and hang the apply on
 # something nobody was shown. The live display for this script is GitHub #33.
 bundle_outcome=failed
-step_begin "packages"
+step_begin_quiet "packages"
 
 # tee rather than capture-then-print: a fresh machine spends tens of minutes in here and
 # needs to see it working. PIPESTATUS[0] is brew's status; $? would be tee's, always 0.

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -8,8 +8,10 @@
 #
 # teardown:none
 
+{{ template "sh-ui.sh" . }}
+
 if ! command -v brew &>/dev/null; then
-  echo "Homebrew not found — skipping package install."
+  step_warn "packages" "Homebrew not found"
   exit 0
 fi
 
@@ -154,7 +156,21 @@ handle_bundle_result() {
 # unset trap reference just expands empty, so rm -f no-ops on the happy path instead of
 # needing a second trap registration.
 bundle_log=$(mktemp -t dotfiles-brew-bundle)
-trap 'rm -f "$bundle_log" "$retry_log"' EXIT
+# $? first, before the removals: rm -f always returns 0, so a finalizer reading
+# it afterward settles a failed run as a success.
+ui_exit() {
+  ui_st=$?
+  rm -f "$bundle_log" "$retry_log"
+  ui_finalize "$ui_st"
+}
+trap ui_exit EXIT
+
+# The step line opens here, before brew is entered, and closes after it exits.
+# Nothing is drawn in between on purpose: a cask's sudo prompt writes to
+# /dev/tty past any redirect, onto the same stream a spinner would redraw, so a
+# frame landing there can erase a password prompt and hang the apply on
+# something nobody was shown. The live display for this script is GitHub #33.
+step_begin "packages"
 
 # tee rather than capture-then-print: a fresh machine spends tens of minutes in here and
 # needs to see it working. PIPESTATUS[0] is brew's status; $? would be tee's, always 0.
@@ -162,6 +178,12 @@ brew bundle --file=/dev/stdin <<<"$brewfile" 2>&1 | tee "$bundle_log"
 bundle_status=${PIPESTATUS[0]}
 
 handle_bundle_result "$bundle_log" "$bundle_status" 1
+
+if [ "$bundle_status" -eq 0 ]; then
+  step_ok "packages" "Brewfile applied"
+else
+  step_warn "packages" "Homebrew reported failures"
+fi
 
 # Still 0, having named the failures. Stopping the apply here would strand every later
 # script over one unavailable formula; dotfiles-doctor is what carries the gap forward.

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -78,7 +78,14 @@ handle_bundle_result() {
   local log="$1" status="$2" allow_retry="$3"
   local failed_entries fetch_batch missing
 
-  [ "$status" -eq 0 ] && return 0
+  # Recorded rather than inferred by the caller, because the caller only ever
+  # sees the FIRST bundle's status and a retry that succeeds would otherwise be
+  # reported as a failure. The retry reaches this same early return through the
+  # recursive call below.
+  [ "$status" -eq 0 ] && {
+    bundle_outcome=ok
+    return 0
+  }
 
   failed_entries=$(parse_failed_entries "$log")
   if [ -n "$failed_entries" ]; then
@@ -170,6 +177,7 @@ trap ui_exit EXIT
 # /dev/tty past any redirect, onto the same stream a spinner would redraw, so a
 # frame landing there can erase a password prompt and hang the apply on
 # something nobody was shown. The live display for this script is GitHub #33.
+bundle_outcome=failed
 step_begin "packages"
 
 # tee rather than capture-then-print: a fresh machine spends tens of minutes in here and
@@ -179,7 +187,7 @@ bundle_status=${PIPESTATUS[0]}
 
 handle_bundle_result "$bundle_log" "$bundle_status" 1
 
-if [ "$bundle_status" -eq 0 ]; then
+if [ "$bundle_outcome" = "ok" ]; then
   step_ok "packages" "Brewfile applied"
 else
   step_warn "packages" "Homebrew reported failures"

--- a/run_onchange_install-vscode-extensions.sh.tmpl
+++ b/run_onchange_install-vscode-extensions.sh.tmpl
@@ -9,12 +9,34 @@
 
 set -e
 
+{{ template "sh-ui.sh" . }}
+
+# $? is read as the trap body's literal first statement. A finalizer that reads
+# it any later gets the status of whatever ran in between, and settles a failed
+# run as a success.
+ui_exit() {
+  ui_st=$?
+  ui_finalize "$ui_st"
+}
+trap ui_exit EXIT
+
 if ! command -v code &>/dev/null; then
-  echo "VS Code CLI not found — skipping extension install."
+  step_warn "vscode ext" "VS Code CLI not found"
   exit 0
 fi
 
-echo "Installing VS Code extensions..."
+# Read into a variable before the loop rather than straight off a heredoc: the
+# live line needs a denominator, and a heredoc redirect gives the loop no way
+# to know how many entries are coming.
+extensions=$(
+  cat <<'EXTEOF'
+{{ include "dot_config/vscode-extensions.txt" }}
+EXTEOF
+)
+ext_total=$(printf '%s\n' "$extensions" | grep -cE '^[^#[:space:]]' || true)
+ext_done=0
+
+step_begin "vscode ext"
 
 # This loop used to end `2>/dev/null || true`, which threw away the exit code and the
 # reason together: an extension pulled from the marketplace read exactly like a machine
@@ -25,21 +47,24 @@ failed=()
 
 while IFS= read -r ext; do
   [[ "$ext" =~ ^#.*$ || -z "$ext" ]] && continue
+  ext_done=$((ext_done + 1))
+  step_tick "$ext_done" "$ext_total" "$ext"
   if ! code --install-extension "$ext" --force; then
     failed+=("$ext")
   fi
-done <<'EXTEOF'
-{{ include "dot_config/vscode-extensions.txt" }}
+done <<EXTEOF
+$extensions
 EXTEOF
 
 # The count test is not decoration. bash 3.2 expands an empty array to a single empty word,
 # so an unconditional summary would print a heading with a blank line under it on a clean
 # run — a failure with no name attached, which is the bug wearing the fix's clothes.
 if [ "${#failed[@]}" -gt 0 ]; then
+  step_warn "vscode ext" "${#failed[@]} of $ext_total refused"
   echo "VS Code ran, but could not install these extensions (its errors are above):"
   printf '  %s\n' "${failed[@]}"
 else
-  echo "VS Code extensions installed."
+  step_ok "vscode ext" "$ext_total installed"
 fi
 
 # Named the failures and still succeeded, on purpose: a stale extension id is not a reason

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -469,13 +469,14 @@ ui_apply_venue() {
 # A run_ script body that animates long enough for a harness to act on a frame,
 # then settles.
 ui_probe_body() {
-	cat <<'BODY'
+	local frames="${1:-15}"
+	cat <<BODY
 step_begin 'probe'
 i=0
-while [ "$i" -lt 15 ]; do
-	step_tick "$i" 15 'working'
+while [ "\$i" -lt $frames ]; do
+	step_tick "\$i" $frames 'working'
 	sleep 0.1
-	i=$((i + 1))
+	i=\$((i + 1))
 done
 step_ok 'probe' 'done'
 BODY
@@ -589,4 +590,74 @@ ui_pty_status() {
 	local st=0
 	ui_pty "$@" || st=$?
 	printf '%s' "$st"
+}
+
+# One field out of capture-shape.py's report, by name.
+ui_shape() {
+	local cap="$1" glyphs="$2" field="$3"
+	python3 "$(ui_src)/tests/support/capture-shape.py" "$cap" "$glyphs" |
+		tr ' ' '\n' | sed -n "s/^$field=//p"
+}
+
+# Does the capture end with the cursor restore, as real bytes rather than as
+# the eight characters `\033[?25h`?
+ui_ends_with_restore() {
+	LC_ALL=C tail -c 6 "$1" | LC_ALL=C od -An -tx1 | tr -d ' \n' |
+		grep -q '^1b5b3f323568$'
+}
+
+# A script that fails by one of four routes, each with its own way of reaching
+# a non-zero exit, all of them going through the caller's EXIT trap.
+#
+# The trap captures $? as its literal first statement. That ordering is the
+# whole point: install-prerequisites' real trap opens with `rm -f`, which
+# always returns 0, so a finalizer reading $? after it would settle a failing
+# script's line as a success.
+ui_failure_fixture() {
+	local path="$1" kit="$2" route="$3" work=''
+	case "$route" in
+	# The helper's own loop gives up. spin_until returns 1 on timeout, and
+	# that status has to reach the caller rather than being swallowed.
+	helper-loop) work='spin_until "waiting" 1 false' ;;
+	# The work a helper wraps fails, and its status comes back through the
+	# helper rather than around it.
+	wrapped) work='job() { sleep 1; return 7; }
+log="$(mktemp)"
+job >"$log" 2>&1 &
+spin_on_log $! "work" "$log"' ;;
+	# A region no helper owns aborts under errexit. Six of the ten scripts
+	# set -e, so a step settled as ✓ followed by an abort would otherwise
+	# exit non-zero with a tick as its last word.
+	bare-region) work='false' ;;
+	explicit-exit) work='exit 5' ;;
+	esac
+	cat >"$path" <<FIXTURE
+#!/bin/bash
+set -eu
+. '$kit'
+cleanup() {
+	st=\$?
+	ui_finalize "\$st"
+}
+trap cleanup EXIT
+step_begin 'work'
+step_tick 1 3 'running'
+step_tick 2 3 'running'
+$work
+step_ok 'work' 'done'
+FIXTURE
+	chmod +x "$path"
+}
+
+# C-6's failing example as a kit: the cursor is hidden once before the first
+# frame and restored once after the last, so every frame drawn in between sits
+# inside one open hide span. A clean run looks right and Ctrl-C during the
+# two-minute package install leaves the user with no cursor until they run
+# `reset`.
+ui_hide_once_kit() {
+	local src="$1" out="$2"
+	sed -e 's|_ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  $1${_UI_SHOW}"|_ui_write "${_UI_HIDE}"; _ui_write "${_UI_ERASE}  $(_ui_glyph)  $1"|' \
+		-e 's|_ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  ${_UI_STEP_LABEL:-}  ${count}${detail}${_UI_SHOW}"|_ui_write "${_UI_ERASE}  $(_ui_glyph)  ${_UI_STEP_LABEL:-}  ${count}${detail}"|' \
+		"$src" >"$out"
+	grep -q '_ui_write "${_UI_HIDE}"; ' "$out"
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -661,3 +661,140 @@ ui_hide_once_kit() {
 		"$src" >"$out"
 	grep -q '_ui_write "${_UI_HIDE}"; ' "$out"
 }
+
+# --- the ten templated run_ scripts ----------------------------------------
+
+ui_ten_scripts() {
+	cat <<'LIST'
+run_before_provision-age-key.sh.tmpl
+run_once_before_install-prerequisites.sh.tmpl
+run_onchange_after_fetch-licensed-fonts.sh.tmpl
+run_onchange_after_install-claude-plugins.sh.tmpl
+run_onchange_after_install-global-node-packages.sh.tmpl
+run_onchange_after_load-launchagents.sh.tmpl
+run_onchange_after_restore-agent-skills.sh.tmpl
+run_onchange_configure-raycast.sh.tmpl
+run_onchange_install-packages.sh.tmpl
+run_onchange_install-vscode-extensions.sh.tmpl
+LIST
+}
+
+# Stubs for every binary the ten drive as a tool, drawn by effect rather than
+# by location.
+#
+# A binary is stubbed when its real invocation's effect leaves the harness:
+# network, launchd, credentials, GUI and app state, package state. Two members
+# were measured doing live damage from a passthrough PATH. `launchctl bootout`
+# runs against the user's own auto-sync agent, and `defaults` sits on
+# /usr/bin, reads like a system utility, and writes com.raycast.macos for real
+# on every run.
+#
+# The shell's own utilities are never stubbed. `sleep`, `tr`, `grep`, `tail`,
+# `sed`, `awk`, `stty`, `mktemp`, `cat`, and `date` resolve from /usr/bin:/bin,
+# because a no-op `sleep` collapses the kit's frame loop and leaves the harness
+# measuring a kit that cannot animate.
+ui_write_stubs() {
+	local v="$1" name
+	mkdir -p "$v/stubs" "$v/clt/usr/bin"
+
+	for name in npm pnpm npx claude code curl launchctl open osascript killall \
+		defaults mas gh node corepack softwareupdate sudo pkgutil; do
+		printf '#!/bin/bash\nexit 0\n' >"$v/stubs/$name"
+		chmod +x "$v/stubs/$name"
+	done
+
+	# Present the Command Line Tools as installed. With have_clt false the
+	# script falls through to `spin_until "Waiting for the install to finish"
+	# 3600`, and a venue that closes every install route turns that bound into
+	# an hour.
+	: >"$v/clt/usr/bin/clang"
+	: >"$v/clt/usr/bin/git"
+	chmod +x "$v/clt/usr/bin/clang" "$v/clt/usr/bin/git"
+	cat >"$v/stubs/xcode-select" <<STUB
+#!/bin/bash
+if [ "\$1" = "-p" ]; then
+	echo "$v/clt"
+	exit 0
+fi
+exit 0
+STUB
+	chmod +x "$v/stubs/xcode-select"
+
+	# brew has to answer `command -v`, or install-prerequisites takes its miss
+	# branch and runs Homebrew's installer off the network. `bundle` reads the
+	# Brewfile from stdin and has to drain it.
+	cat >"$v/stubs/brew" <<'STUB'
+#!/bin/bash
+case "$1" in
+bundle)
+	cat >/dev/null
+	echo "Homebrew Bundle complete! 0 Brewfile dependencies now installed."
+	;;
+shellenv) : ;;
+esac
+exit 0
+STUB
+	chmod +x "$v/stubs/brew"
+
+	# Signed out, which is the branch a harness can honestly take: the real
+	# `op read` blocks on interactive auth for as long as you let it.
+	cat >"$v/stubs/op" <<'STUB'
+#!/bin/bash
+case "$1" in
+account) exit 1 ;;
+esac
+exit 1
+STUB
+	chmod +x "$v/stubs/op"
+}
+
+# Renders one of the ten into its own venue and returns that venue's path.
+#
+# Venue state is per script because one shared home is jointly unsatisfiable.
+# provision-age-key needs a seeded key to take its early exit, since without
+# one it sources brew's shellenv by absolute path and then blocks on real
+# 1Password auth. install-claude-plugins needs that same path empty, because
+# with a key present its render takes a decrypt branch no test config can
+# serve and fails outright.
+ui_ten_venue() {
+	local root="$1" tmpl="$2"
+	local v="$root/${tmpl%.sh.tmpl}"
+	mkdir -p "$v/home" "$v/dest"
+	printf '[data]\n  machine_role = "work"\n' >"$v/chezmoi.toml"
+	ui_write_stubs "$v"
+
+	if [ "$tmpl" = "run_before_provision-age-key.sh.tmpl" ]; then
+		mkdir -p "$v/home/.config/chezmoi"
+		printf 'AGE-SECRET-KEY-1TESTONLYNOTAREALKEY\n' \
+			>"$v/home/.config/chezmoi/key.txt"
+	fi
+
+	(
+		unset XDG_CONFIG_HOME XDG_CACHE_HOME
+		HOME="$v/home" chezmoi execute-template \
+			--source "$(ui_src)" --config "$v/chezmoi.toml" \
+			--destination "$v/dest" <"$(ui_src)/$tmpl" >"$v/script.sh"
+	)
+	printf '%s' "$v"
+}
+
+# Runs a rendered script under its stubs.
+#
+# NVM_DIR and HOMEBREW_PREFIX are SET to venue paths rather than unset, and the
+# difference is not cosmetic. Both scripts that consult them read
+# `${HOMEBREW_PREFIX:-/opt/homebrew}`, so unsetting the variable hands the
+# script the real Homebrew prefix, whose opt/nvm/nvm.sh exists on this machine.
+# Sourcing it prepends real node ahead of the stubs and the run reaches a live
+# `npm install -g`.
+ui_run_ten() {
+	local v="$1"
+	shift
+	(
+		unset XDG_CONFIG_HOME XDG_CACHE_HOME NO_COLOR DOTFILES_NO_PROGRESS
+		export HOME="$v/home"
+		export NVM_DIR="$v/home/.nvm"
+		export HOMEBREW_PREFIX="$v/home/.no-homebrew"
+		export PATH="$v/stubs:/usr/bin:/bin"
+		ui_pty "$@" -- /bin/bash "$v/script.sh"
+	)
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -56,7 +56,7 @@ sg_age_identity_path() {
 }
 
 # Generates one age identity for the whole case that calls it and leaves its
-# recipient (public key) in $SG_AGE_RECIPIENT. One key per case is enough —
+# recipient (public key) in $SG_AGE_RECIPIENT. One key per case is enough—
 # a real machine has exactly one — and $SG_AGE_KEYFILE is what the no-key
 # case removes to prove the fallback in C-5.
 sg_age_setup() {
@@ -229,7 +229,7 @@ sg_prepare_target() {
 
 	case "$live" in
 	near | far)
-		# $dist filler/match commits older than HEAD, so the match commit —
+		# $dist filler/match commits older than HEAD, so the match commit—
 		# the one whose target state the live file below will hold — sits
 		# exactly $dist commits behind HEAD in this path's own history.
 		match_body="$(sg_gen_body "$content_lines" "$content_bytes" "MATCH-${nonce}")"
@@ -260,7 +260,7 @@ sg_prepare_target() {
 	printf '%s' "$live_body" >"$home_abs"
 	touch_at "$live_mtime_epoch" "$home_abs"
 
-	# Every edited row in C-1's table is edited *after* HEAD is committed —
+	# Every edited row in C-1's table is edited *after* HEAD is committed—
 	# an uncommitted change sitting on top of real history, never the only
 	# state a path has ever had.
 	if [ "$src" = "edited" ]; then
@@ -346,4 +346,102 @@ sg_assert_multi_block_set() {
 	done
 	got="$(printf '%s\n' "$output" | grep -cE '^        \.')"
 	[ "$got" -eq "${#BLOCK_TARGETS[@]}" ] || return 1
+}
+
+# --- progress-display harness (constitution C-1..C-14, GitHub #16) ----------
+#
+# Everything below serves tests/progress.bats. It lives here rather than in
+# that file because tests/lint.bats scans this file too, so the bash 3.2
+# assertion rules above apply to it and stay enforced.
+
+# The repo root, resolved from BATS_TEST_DIRNAME rather than $PWD: a checker
+# that copies this suite into a scratch worktree has to measure the copy, not
+# whatever tree the process happens to be running from.
+ui_src() {
+	printf '%s' "${BATS_TEST_DIRNAME}/.."
+}
+
+# A chezmoi config carrying machine_role, written once per test into
+# $BATS_TEST_TMPDIR and echoed back by path.
+#
+# Rendering under a synthetic $HOME without one fails outright with
+# `map has no entry for key "machine_role"`, and that key decides the
+# Brewfile's size. tests/packages.bats:30-43 is the same idea; this is the
+# whole-script form of it.
+ui_fixture_config() {
+	local cfg="$BATS_TEST_TMPDIR/chezmoi.toml"
+	if [ ! -f "$cfg" ]; then
+		printf '[data]\n  machine_role = "work"\n' >"$cfg"
+	fi
+	printf '%s' "$cfg"
+}
+
+# Renders .chezmoitemplates/sh-ui.sh on its own, the way a run_ script's
+# `{{ template "sh-ui.sh" . }}` include would.
+#
+# Every flag here is load-bearing. --source is what makes the include resolve
+# at all: bare `execute-template` resolves its source dir from
+# $HOME/.local/share/chezmoi, so under a synthetic $HOME it finds nothing and
+# the include renders empty—the defect still live at
+# tests/install-failures.bats:37. --config and --destination pin the other two
+# resolution surfaces, because with XDG unset and $HOME real chezmoi still
+# falls back through $HOME to the user's own ~/.config.
+ui_render_kit() {
+	local out="$1"
+	env -u XDG_CONFIG_HOME -u XDG_CACHE_HOME \
+		chezmoi execute-template \
+		--source "$(ui_src)" \
+		--config "$(ui_fixture_config)" \
+		--destination "$BATS_TEST_TMPDIR/dest" \
+		<<<'{{ template "sh-ui.sh" . }}' >"$out"
+}
+
+# Counts lines of $2 matching extended regex $1. Anchored assertions need a
+# regex, and assert_contains hands its needle to `grep -qF`, so a settled
+# line's shape (`^  ✓  `) cannot be expressed through it.
+ui_count_matching() {
+	printf '%s\n' "${2-$output}" | grep -cE "$1" || true
+}
+
+# Counts ESC (0x1b) bytes in a file. Bytes, not matching lines: `grep -c`
+# answers a different question and reads as a pass on a file whose every
+# escape sequence shares one line.
+ui_esc_count() {
+	LC_ALL=C tr -cd '\033' <"$1" | wc -c | tr -d ' '
+}
+
+# The pty driver. See tests/support/pty-run.py for what each mode measures.
+ui_pty() {
+	python3 "$(ui_src)/tests/support/pty-run.py" "$@"
+}
+
+# The kit's spinner glyphs, read out of the rendered kit rather than
+# hardcoded, so a kit that changes its frames does not silently stop being
+# measured. Passed to the pty driver as the thing it counts.
+ui_glyphs() {
+	local kit="$1"
+	sed -n 's/^SPINNER_FRAMES=(\(.*\))$/\1/p' "$kit" | tr -d ' \n'
+}
+
+# A fixture that animates: it draws frames on /dev/tty for long enough that a
+# harness can act on one, then settles. Every venue in this suite needs a
+# script under test that is genuinely mid-animation, and `trap '' HUP` is what
+# lets it survive the one injection built by closing the pty master.
+ui_write_animating_fixture() {
+	local path="$1" kit="$2" frames="${3:-12}"
+	cat >"$path" <<FIXTURE
+#!/bin/bash
+set -eu
+trap '' HUP
+. '$kit'
+step_begin 'work'
+i=0
+while [ "\$i" -lt $frames ]; do
+	step_tick "\$i" $frames 'running'
+	sleep 0.1
+	i=\$((i + 1))
+done
+step_ok 'work' 'done'
+FIXTURE
+	chmod +x "$path"
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -668,10 +668,17 @@ FIXTURE
 # `reset`.
 ui_hide_once_kit() {
 	local src="$1" out="$2"
-	sed -e 's|_ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  $1${_UI_SHOW}"|_ui_write "${_UI_HIDE}"; _ui_write "${_UI_ERASE}  $(_ui_glyph)  $1"|' \
-		-e 's|_ui_write "${_UI_ERASE}${_UI_HIDE}  $(_ui_glyph)  ${_UI_STEP_LABEL:-}  ${count}${detail}${_UI_SHOW}"|_ui_write "${_UI_ERASE}  $(_ui_glyph)  ${_UI_STEP_LABEL:-}  ${count}${detail}"|' \
+	# Written as generic substitutions rather than as whole-line matches. The
+	# line-matching version stopped biting the moment the frame writers gained
+	# their width trim, and a builder that silently produces an unmodified kit
+	# hands the check a failing example that cannot fail. The greps below are
+	# what turn that into a loud failure instead of a quiet pass.
+	sed -e 's|${_UI_ERASE}${_UI_HIDE}|${_UI_ERASE}|g' \
+		-e 's|)${_UI_SHOW}"|)"|g' \
+		-e 's|^  _ui_measure$|  _ui_measure; [ -n "${_UI_HIDDEN:-}" ] \|\| { _ui_write "$_UI_HIDE"; _UI_HIDDEN=1; }|' \
 		"$src" >"$out"
-	grep -q '_ui_write "${_UI_HIDE}"; ' "$out"
+	[ "$(grep -c '\${_UI_ERASE}\${_UI_HIDE}' "$out")" -eq 0 ]
+	grep -q '_UI_HIDDEN=1' "$out"
 }
 
 # --- the ten templated run_ scripts ----------------------------------------

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -518,3 +518,75 @@ ui_distinct_glyphs() {
 	done
 	printf '%s' "$found"
 }
+
+# Builds one script for the fail-open matrix: a direction (does the underlying
+# work succeed or fail?) crossed with a display fault.
+#
+# In the failing direction the work's status has to reach the caller THROUGH a
+# kit helper, as spin_on_log's wrapped job. A fixture that ends in a bare
+# `exit 7` on its own tests nothing about the kit; it tests that `exit` works.
+#
+# `trap '' HUP` is required by the unwritable injection and harmless in the
+# rest: the only way to make /dev/tty present-but-unwritable is closing the pty
+# master, which raises SIGHUP on the whole foreground process group, and
+# without the trap the script dies at 129 before it can spill anything.
+ui_fail_open_fixture() {
+	local path="$1" kit="$2" direction="$3" injection="$4"
+	local inject=''
+	case "$injection" in
+	frames-unset) inject='unset SPINNER_FRAMES # INJECT:frames-unset' ;;
+	frames-empty) inject='SPINNER_FRAMES=() # INJECT:frames-empty' ;;
+	bar-nan) inject='progress_bar "not-a-number" >/dev/null # INJECT:bar-nan' ;;
+	esac
+
+	local work='return 0'
+	if [ "$direction" = "fail" ]; then
+		work='return 7'
+	fi
+
+	cat >"$path" <<FIXTURE
+#!/bin/bash
+set -eu
+trap '' HUP
+. '$kit'
+cleanup() {
+	st=\$?
+	ui_finalize "\$st"
+}
+trap cleanup EXIT
+$inject
+job() {
+	sleep 1
+	$work
+}
+log="\$(mktemp)"
+step_begin 'work'
+job >"\$log" 2>&1 &
+spin_on_log \$! 'work' "\$log"
+step_ok 'work' 'done'
+FIXTURE
+	chmod +x "$path"
+}
+
+# A kit whose frame write is unguarded, which is C-7's own failing example: a
+# cosmetic write to a vanished tty takes the script down under errexit, and
+# every package after that point goes uninstalled.
+ui_unguarded_kit() {
+	local src="$1" out="$2"
+	sed 's|^  ( printf .*$|  printf "%s" "$1" >\&9|' "$src" >"$out"
+	# Both halves of the guard have to be gone, not just the subshell. An
+	# earlier version of this replacement left the trailing `|| true` in place
+	# and produced a kit that still swallowed the failure, so the check it
+	# feeds passed while proving nothing.
+	grep -q '^  printf "%s" "\$1" >&9$' "$out"
+	grep -vq '|| true' <(grep -A1 '^_ui_write()' "$out")
+}
+
+# ui_pty's exit status, without errexit eating the case first. bats runs test
+# bodies under `set -e`, so a bare `ui_pty ...; st=$?` never reaches the
+# assignment on any run that fails, which is exactly the run worth measuring.
+ui_pty_status() {
+	local st=0
+	ui_pty "$@" || st=$?
+	printf '%s' "$st"
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -913,6 +913,20 @@ ui_widest_line() {
 # loop ticks with entries like "Font: Operator Mono Lig Nerd Font", which blows
 # past 40 columns on its own, so a narrow-terminal check driven by a short
 # label proves nothing.
+# A caller that opens a step and then blocks without ticking. This is the shape
+# every adopted script actually has: it ticks once per item, then sits inside an
+# install for seconds. ui_probe_body ticks in a tight loop, which proves only
+# that step_tick redraws when called — it cannot see a kit that never redraws on
+# its own, and that kit shows one frozen glyph for the whole item.
+ui_probe_body_blocking() {
+	local secs="${1:-3}"
+	cat <<BODY
+step_begin 'blocking'
+sleep $secs
+step_ok 'blocking' 'done'
+BODY
+}
+
 ui_probe_body_wide() {
 	cat <<'BODY'
 step_begin 'licensed fonts'

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -445,3 +445,76 @@ step_ok 'work' 'done'
 FIXTURE
 	chmod +x "$path"
 }
+
+# Builds a self-contained chezmoi source dir holding a copy of the kit and one
+# run_ script, plus its own destination, home, and config.
+#
+# The kit is copied in rather than referenced because a `{{ template
+# "sh-ui.sh" . }}` include resolves against the CONFIGURED source dir, not the
+# file being rendered. A venue that points --source at a fixture and expects
+# the repo's kit gets an empty include and a script that calls helpers nothing
+# defined.
+ui_apply_venue() {
+	local v="$1" body="$2"
+	mkdir -p "$v/src/.chezmoitemplates" "$v/dest" "$v/home"
+	cp "$(ui_src)/.chezmoitemplates/sh-ui.sh" "$v/src/.chezmoitemplates/sh-ui.sh"
+	{
+		printf '#!/bin/bash\n'
+		printf '{{ template "sh-ui.sh" . }}\n'
+		printf '%s\n' "$body"
+	} >"$v/src/run_onchange_probe.sh.tmpl"
+	printf '[data]\n  machine_role = "work"\n' >"$v/chezmoi.toml"
+}
+
+# A run_ script body that animates long enough for a harness to act on a frame,
+# then settles.
+ui_probe_body() {
+	cat <<'BODY'
+step_begin 'probe'
+i=0
+while [ "$i" -lt 15 ]; do
+	step_tick "$i" 15 'working'
+	sleep 0.1
+	i=$((i + 1))
+done
+step_ok 'probe' 'done'
+BODY
+}
+
+# Runs `chezmoi apply` against a venue, under whichever pty mode the caller
+# names.
+#
+# Every flag and every unset here was measured. The three path flags bypass
+# chezmoi's resolution entirely, which is the only deterministic way to keep a
+# test off the user's live config: with XDG unset and $HOME real, chezmoi still
+# falls back through $HOME to the same ~/.config. The env scrub is the backstop
+# for what the SCRIPTS resolve on their own, and NVM_DIR is why it exists. The
+# login shell exports it, so `${NVM_DIR:-$HOME/.nvm}` never takes its default
+# and a synthetic home is ignored.
+ui_apply() {
+	local v="$1"
+	shift
+	(
+		unset NVM_DIR HOMEBREW_PREFIX XDG_CONFIG_HOME XDG_CACHE_HOME
+		unset NO_COLOR DOTFILES_NO_PROGRESS
+		export HOME="$v/home"
+		ui_pty "$@" -- chezmoi apply \
+			--source "$v/src" --destination "$v/dest" --config "$v/chezmoi.toml"
+	)
+}
+
+# How many of the kit's frame glyphs appear anywhere in a capture.
+#
+# Distinct glyphs, not total frames: a single static draw satisfies "escape
+# codes were emitted" while showing a frozen character, which is
+# indistinguishable from the hang this whole job exists to rule out.
+ui_distinct_glyphs() {
+	local cap="$1" g="$2" i=0 found=0
+	while [ "$i" -lt "${#g}" ]; do
+		if grep -qF -- "${g:$i:1}" "$cap"; then
+			found=$((found + 1))
+		fi
+		i=$((i + 1))
+	done
+	printf '%s' "$found"
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -533,11 +533,23 @@ ui_distinct_glyphs() {
 # without the trap the script dies at 129 before it can spill anything.
 ui_fail_open_fixture() {
 	local path="$1" kit="$2" direction="$3" injection="$4"
-	local inject=''
+	local inject='' sttydir
 	case "$injection" in
 	frames-unset) inject='unset SPINNER_FRAMES # INJECT:frames-unset' ;;
 	frames-empty) inject='SPINNER_FRAMES=() # INJECT:frames-empty' ;;
 	bar-nan) inject='progress_bar "not-a-number" >/dev/null # INJECT:bar-nan' ;;
+	stty-zero)
+		# The one injection that needs a binary rather than a variable, and the
+		# only place in this suite where a shell utility is stubbed. It is an
+		# injected fault here, not a venue: everywhere else `stty` resolves for
+		# real, because a harness that replaces the shell's own utilities ends
+		# up measuring a kit that cannot animate.
+		sttydir="$(dirname "$path")/stty-zero"
+		mkdir -p "$sttydir"
+		printf '#!/bin/bash\necho "0 0"\n' >"$sttydir/stty"
+		chmod +x "$sttydir/stty"
+		inject="PATH=\"$sttydir:\$PATH\" # INJECT:stty-zero"
+		;;
 	esac
 
 	local work='return 0'
@@ -883,4 +895,26 @@ s = s.replace(old2, old2 + '\nkill "$ui_spin" 2>/dev/null || true', 1)
 open(p, 'w').write(s)
 EOF
 	grep -q 'ui_spin=' "$script"
+}
+
+# The widest live line in a capture, in display columns.
+ui_widest_line() {
+	python3 "$(ui_src)/tests/support/line-width.py" "$1"
+}
+
+# A probe whose live line is as long as the real ones get. The licensed-fonts
+# loop ticks with entries like "Font: Operator Mono Lig Nerd Font", which blows
+# past 40 columns on its own, so a narrow-terminal check driven by a short
+# label proves nothing.
+ui_probe_body_wide() {
+	cat <<'BODY'
+step_begin 'licensed fonts'
+i=0
+while [ "$i" -lt 15 ]; do
+	step_tick "$i" 15 'Font: Operator Mono Lig Nerd Font'
+	sleep 0.1
+	i=$((i + 1))
+done
+step_ok 'licensed fonts' 'done'
+BODY
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -798,3 +798,89 @@ ui_run_ten() {
 		ui_pty "$@" -- /bin/bash "$v/script.sh"
 	)
 }
+
+# One field out of bundle-intervals.py's report, by name.
+ui_intervals() {
+	local cap="$1" glyphs="$2" field="$3"
+	python3 "$(ui_src)/tests/support/bundle-intervals.py" "$cap" "$glyphs" |
+		tr ' ' '\n' | sed -n "s/^$field=//p"
+}
+
+# A `brew` stub that holds each bundle interval open and brackets it on
+# /dev/tty.
+#
+# The dwell is load-bearing and was measured as the only variable that decided
+# the answer. Against a violating script the same check reported ok with an
+# instant stub and `301 tty bytes inside bundle 1` with the same stub holding
+# 0.6s. A stub that returns immediately leaves no window for a frame to land
+# in, so the check cannot fail and certifies whatever it is given.
+#
+# Regime `retry` produces the one state that reaches the second bundle: a fetch
+# phase failure with no `<Verb> <entry> has failed!` line, one `Failed to fetch`
+# line, and `brew info` resolving a strict subset of the batched names.
+ui_write_brew_bundle_stub() {
+	local v="$1" regime="$2" drop="$3" keep="$4"
+	cat >"$v/stubs/brew" <<STUB
+#!/bin/bash
+BUNDLE_LOG="$v/bundle-calls.log"
+case "\$1" in
+info)
+	if [ "\$2" = "$drop" ]; then exit 1; fi
+	exit 0
+	;;
+bundle)
+	n=\$((\$(wc -l <"\$BUNDLE_LOG" 2>/dev/null || echo 0) + 1))
+	echo "bundle \$n" >>"\$BUNDLE_LOG"
+	printf 'BUNDLE-ENTER-%s' "\$n" >/dev/tty 2>/dev/null || true
+	cat >/dev/null
+	sleep 0.6
+	printf 'BUNDLE-EXIT-%s' "\$n" >/dev/tty 2>/dev/null || true
+	if [ "$regime" = "retry" ] && [ "\$n" -eq 1 ]; then
+		echo "Fetching $keep, $drop"
+		echo '\`brew bundle\` failed! Failed to fetch $keep, $drop' >&2
+		echo 'Error: No available formula with the name "$drop".' >&2
+		exit 1
+	fi
+	echo "Homebrew Bundle complete! 0 Brewfile dependencies now installed."
+	exit 0
+	;;
+esac
+exit 0
+STUB
+	chmod +x "$v/stubs/brew"
+	: >"$v/bundle-calls.log"
+}
+
+# Two real Brewfile entry names. A name the render never contained would make
+# the drop-and-retry gate vacuous, the same reason install-failures.bats reads
+# its fixtures out of the render.
+ui_brewfile_names() {
+	local cfg
+	cfg="$(ui_fixture_config)"
+	env -u XDG_CONFIG_HOME -u XDG_CACHE_HOME chezmoi execute-template \
+		--source "$(ui_src)" --config "$cfg" <<<'{{ template "Brewfile" . }}' |
+		grep '^brew "' | head -2 | sed -E 's/^brew "([^"]+)"$/\1/'
+}
+
+# The clause's own failing example: the installer with a frame loop running
+# across its `brew bundle`. C-4 still passes against this, because the settled
+# line still reaches stdout on every path, which is exactly why the guarantee
+# needs a venue that watches /dev/tty instead.
+ui_animate_over_bundle() {
+	local script="$1"
+	python3 - "$script" <<'EOF'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+old = 'brew bundle --file=/dev/stdin <<<"$brewfile" 2>&1 | tee "$bundle_log"'
+assert old in s, "bundle invocation not found in rendered script"
+s = s.replace(old,
+  '( while :; do step_tick 1 1 "installing"; sleep 0.1; done ) &\n'
+  'ui_spin=$!\n' + old, 1)
+old2 = 'bundle_status=${PIPESTATUS[0]}'
+assert old2 in s
+s = s.replace(old2, old2 + '\nkill "$ui_spin" 2>/dev/null || true', 1)
+open(p, 'w').write(s)
+EOF
+	grep -q 'ui_spin=' "$script"
+}

--- a/tests/install-failures.bats
+++ b/tests/install-failures.bats
@@ -30,11 +30,17 @@ setup() {
 # Rendered with the real $HOME regardless of what setup() just pointed $HOME at,
 # so the claude-plugins template's decrypt gate sees the key that's actually
 # there. That gate is why this file needs the real $HOME rather than just the
-# real source dir: tests/licensed-fonts.bats renders under the synthetic $HOME
-# with --source, which is enough only because its template reads no config data.
+# real source dir.
+#
+# --source is separate and equally required. Without it the script body comes
+# from the tree under test while `{{ template "sh-ui.sh" . }}` resolves against
+# whatever source dir the config names, so a run from a copied tree renders a
+# script that calls step_begin and defines it nowhere. That produced twelve
+# failures at exit 127, none of them on a string assertion, which is a
+# confusing way to learn the render was wrong.
 render_script() {
 	local tmpl="$1" out="$BATS_TEST_TMPDIR/${1%.tmpl}"
-	HOME="$REAL_HOME" chezmoi execute-template <"$SRC/$tmpl" >"$out"
+	HOME="$REAL_HOME" chezmoi execute-template --source "$SRC" <"$SRC/$tmpl" >"$out"
 	echo "$out"
 }
 
@@ -52,7 +58,7 @@ first_raycast_extension() {
 # fixture name the render never contained would make "not the dropped name" vacuously
 # true, per the constitution's C-1.
 render_brewfile() {
-	HOME="$REAL_HOME" chezmoi execute-template <<<'{{ template "Brewfile" . }}'
+	HOME="$REAL_HOME" chezmoi execute-template --source "$SRC" <<<'{{ template "Brewfile" . }}'
 }
 
 # Raycast's hotkey write ignores $HOME and lands in the real
@@ -403,7 +409,7 @@ STUB
 	chmod +x "$STUBS/code"
 	PATH="$STUBS:/usr/bin:/bin" run bash "$script"
 	[ "$status" -eq 0 ]
-	assert_contains "VS Code extensions installed."
+	assert_contains "  ✓  vscode ext"
 	assert_not_contains "could not install"
 }
 
@@ -566,6 +572,6 @@ STUB
 	chmod +x "$STUBS/claude"
 	PATH="$STUBS:/usr/bin:/bin" run bash "$script"
 	[ "$status" -eq 0 ]
-	assert_contains "Claude Code plugins ready."
+	assert_contains "  ✓  claude plugins"
 	assert_not_contains "did not install"
 }

--- a/tests/progress.bats
+++ b/tests/progress.bats
@@ -174,3 +174,86 @@ setup() {
 	# by side instead of over each other.
 	[ "$(LC_ALL=C tr -cd '\r' <"$v/tty" | wc -c | tr -d ' ')" -ge 2 ]
 }
+
+# ---- C-7: a display fault never changes a script's exit status -------------
+
+# Judged standalone under a pty, never under `chezmoi apply`. The first
+# injection is why: the only way to make /dev/tty present-but-unwritable is
+# closing the pty master, which SIGHUPs the whole group, so under an apply the
+# same run reports 129 for chezmoi and 0 for the script. The noun this measures
+# is the script's own status throughout.
+#
+# `stty size` reporting zero columns is C-7's sixth injection and is not here
+# yet: the kit reads no terminal width, so the fault has nothing to land on. It
+# arrives with the width work, which is what gives it something to break.
+@test "fail-open: a broken display leaves the exit status exactly where it was" {
+	local kit="$BATS_TEST_TMPDIR/sh-ui.sh" d="$BATS_TEST_TMPDIR"
+	ui_render_kit "$kit"
+	local g inj dir fx marker
+	g="$(ui_glyphs "$kit")"
+
+	for inj in none frames-unset frames-empty bar-nan; do
+		for dir in ok fail; do
+			fx="$d/fo-$inj-$dir.sh"
+			ui_fail_open_fixture "$fx" "$kit" "$dir" "$inj"
+
+			# The injection is asserted present on disk before anything is
+			# asserted about the result. An injection that silently failed to
+			# apply produces a clean run and reads as a pass.
+			if [ "$inj" != "none" ]; then
+				assert_contains "INJECT:$inj" "$(cat "$fx")"
+			fi
+
+			marker="$(ui_pty_status --glyphs "$g" --stdout "$d/o" \
+				--stderr "$d/e" --tty-capture "$d/t" --timeout 60 \
+				-- /bin/bash "$fx")"
+			if [ "$dir" = "ok" ]; then
+				[ "$marker" -eq 0 ]
+			else
+				[ "$marker" -eq 7 ]
+			fi
+		done
+	done
+
+	# Injection: /dev/tty present but its writes failing, built by closing the
+	# master while the kit is actively drawing.
+	for dir in ok fail; do
+		fx="$d/fo-unwritable-$dir.sh"
+		ui_fail_open_fixture "$fx" "$kit" "$dir" none
+		marker="$(ui_pty_status --glyphs "$g" --close-master-after-glyphs 2 \
+			--stdout "$d/o" --stderr "$d/e" --tty-capture "$d/t" \
+			--timeout 60 -- /bin/bash "$fx")"
+		if [ "$dir" = "ok" ]; then
+			[ "$marker" -eq 0 ]
+		else
+			[ "$marker" -eq 7 ]
+		fi
+	done
+
+	# Injection: /dev/tty failing to open at all. This is the one that covers
+	# the plain branch; the others all live on the animated one, so without it
+	# nothing tests the branch a detached run takes.
+	for dir in ok fail; do
+		fx="$d/fo-notty-$dir.sh"
+		ui_fail_open_fixture "$fx" "$kit" "$dir" none
+		marker="$(ui_pty_status --setsid --stdout "$d/o" --stderr "$d/e" \
+			--timeout 60 -- /bin/bash "$fx")"
+		if [ "$dir" = "ok" ]; then
+			[ "$marker" -eq 0 ]
+		else
+			[ "$marker" -eq 7 ]
+		fi
+	done
+
+	# The check demonstrates its own discrimination rather than assuming it: a
+	# kit whose frame write is unguarded must fail the succeeding direction
+	# under the unwritable injection. A check that cannot fail against the
+	# clause's own failing example has not been verified, only assumed.
+	local bad="$d/sh-ui-unguarded.sh"
+	ui_unguarded_kit "$kit" "$bad"
+	ui_fail_open_fixture "$d/fo-bad.sh" "$bad" ok none
+	marker="$(ui_pty_status --glyphs "$g" --close-master-after-glyphs 2 \
+		--stdout "$d/o" --stderr "$d/e" --tty-capture "$d/t" --timeout 60 \
+		-- /bin/bash "$d/fo-bad.sh")"
+	[ "$marker" -ne 0 ]
+}

--- a/tests/progress.bats
+++ b/tests/progress.bats
@@ -173,6 +173,20 @@ setup() {
 	# distinct glyphs and fewer than two carriage returns has drawn them side
 	# by side instead of over each other.
 	[ "$(LC_ALL=C tr -cd '\r' <"$v/tty" | wc -c | tr -d ' ')" -ge 2 ]
+
+	# The same live line on a narrow terminal. A wrapped line sends the next
+	# carriage return back to the wrong row, and the animation starts eating
+	# the scrollback above it.
+	#
+	# The width has to come from `stty size </dev/tty`. No script run by
+	# `chezmoi apply` has COLUMNS set or TERM exported, so a kit reading
+	# ${COLUMNS:-80} truncates nothing in production while passing any check
+	# that sets the variable, which is why this uses a real 40-column winsize.
+	local n="$BATS_TEST_TMPDIR/narrow"
+	ui_apply_venue "$n" "$(ui_probe_body_wide)"
+	ui_apply "$n" --cols 40 --glyphs "$g" --stdout "$n/out" \
+		--stderr "$n/err" --tty-capture "$n/tty" --timeout 90
+	[ "$(ui_widest_line "$n/tty")" -le 40 ]
 }
 
 # ---- C-7: a display fault never changes a script's exit status -------------
@@ -183,16 +197,13 @@ setup() {
 # same run reports 129 for chezmoi and 0 for the script. The noun this measures
 # is the script's own status throughout.
 #
-# `stty size` reporting zero columns is C-7's sixth injection and is not here
-# yet: the kit reads no terminal width, so the fault has nothing to land on. It
-# arrives with the width work, which is what gives it something to break.
 @test "fail-open: a broken display leaves the exit status exactly where it was" {
 	local kit="$BATS_TEST_TMPDIR/sh-ui.sh" d="$BATS_TEST_TMPDIR"
 	ui_render_kit "$kit"
 	local g inj dir fx marker
 	g="$(ui_glyphs "$kit")"
 
-	for inj in none frames-unset frames-empty bar-nan; do
+	for inj in none frames-unset frames-empty bar-nan stty-zero; do
 		for dir in ok fail; do
 			fx="$d/fo-$inj-$dir.sh"
 			ui_fail_open_fixture "$fx" "$kit" "$dir" "$inj"

--- a/tests/progress.bats
+++ b/tests/progress.bats
@@ -326,3 +326,63 @@ setup() {
 		--stderr "$w/err" --tty-capture "$w/tty" --timeout 90 || true
 	[ "$(ui_shape "$w/tty" "$g" max_span)" -ge 2 ]
 }
+
+# ---- C-4: all ten templated run_ scripts print a step line when they run ----
+
+# The judgement is on what the run PRINTS, not on what the source contains. A
+# step_ok call inside a branch the run never takes satisfies a source reading
+# and leaves the user watching raw tool output.
+#
+# This is a floor rather than a ceiling. A remaining bare echo elsewhere does
+# not violate it, and whether a script leans on raw tool output as its primary
+# signal is judged separately.
+@test "adoption: every one of the ten leaves a settled line behind" {
+	local root="$BATS_TEST_TMPDIR/ten" tmpl v missing=''
+	mkdir -p "$root"
+	while read -r tmpl; do
+		[ -n "$tmpl" ] || continue
+		v="$(ui_ten_venue "$root" "$tmpl")"
+		ui_run_ten "$v" --stdout "$v/out" --stderr "$v/err" --timeout 120 || true
+		if [ "$(ui_count_matching '^  (✓|!|✗)  ' "$(cat "$v/out")")" -lt 1 ]; then
+			missing="$missing $tmpl"
+		fi
+	done <<EOF
+$(ui_ten_scripts)
+EOF
+	# Named rather than counted: a failure that says "3 scripts" sends the
+	# reader back to run all ten by hand.
+	[ -z "$missing" ] || {
+		echo "no settled line from:$missing"
+		return 1
+	}
+}
+
+# The same ten with no controlling terminal. This is the degradation contract,
+# and the venue is real without launchd: an ssh session run without a tty, a
+# cron job, any setsid run.
+#
+# Two assertions, not one. The escape-code half alone is already true of a kit
+# that gates on stdout, so the settled-line half is what makes this discriminate
+# at all.
+@test "setsid-log: the ten still settle, and write no ESC to stdout, with no terminal" {
+	local root="$BATS_TEST_TMPDIR/ten-setsid" tmpl v bad=''
+	mkdir -p "$root"
+	while read -r tmpl; do
+		[ -n "$tmpl" ] || continue
+		v="$(ui_ten_venue "$root" "$tmpl")"
+		ui_run_ten "$v" --setsid --stdout "$v/out" --stderr "$v/err" \
+			--timeout 120 || true
+		if [ "$(ui_esc_count "$v/out")" -ne 0 ]; then
+			bad="$bad ESC:$tmpl"
+		fi
+		if [ "$(ui_count_matching '^  (✓|!|✗)  ' "$(cat "$v/out")")" -lt 1 ]; then
+			bad="$bad NOLINE:$tmpl"
+		fi
+	done <<EOF
+$(ui_ten_scripts)
+EOF
+	[ -z "$bad" ] || {
+		echo "detached run defects:$bad"
+		return 1
+	}
+}

--- a/tests/progress.bats
+++ b/tests/progress.bats
@@ -257,3 +257,72 @@ setup() {
 		-- /bin/bash "$d/fo-bad.sh")"
 	[ "$marker" -ne 0 ]
 }
+
+# ---- C-6: a failed or interrupted script settles and restores the cursor ---
+
+# Four routes to a non-zero exit, because they fail differently and a script
+# can take any of them. An ERR trap alone would not cover the last one: an
+# explicit `exit N` fires no ERR trap at any `set -E` setting.
+@test "failure: a non-zero exit leaves a settled line and a restored cursor" {
+	local kit="$BATS_TEST_TMPDIR/sh-ui.sh" d="$BATS_TEST_TMPDIR" route fx st
+	ui_render_kit "$kit"
+	local g
+	g="$(ui_glyphs "$kit")"
+
+	for route in helper-loop wrapped bare-region explicit-exit; do
+		fx="$d/fail-$route.sh"
+		ui_failure_fixture "$fx" "$kit" "$route"
+		st="$(ui_pty_status --glyphs "$g" --stdout "$d/o" --stderr "$d/e" \
+			--tty-capture "$d/t" --timeout 60 -- /bin/bash "$fx")"
+
+		[ "$st" -ne 0 ]
+		# The settled line goes to stdout, not to /dev/tty: the live line is
+		# erased before the summary is written, and settled lines are what a
+		# capture keeps.
+		[ "$(ui_count_matching '^  ✗  ' "$(cat "$d/o")")" -ge 1 ]
+		# Real bytes, not the eight characters `\033[?25h`.
+		ui_ends_with_restore "$d/t"
+	done
+}
+
+# Judged under a real pty-wrapped apply with the signal sent to the foreground
+# process group, which is what Ctrl-C actually is.
+#
+# Two axes are pinned because both were measured deciding the answer.
+# Redirection: chezmoi emits ESC]11;? and ESC[6n on a bare pty and waits about
+# four seconds for an answer no harness sends, so an unredirected run reaches
+# its first frame around 5s where a redirected one reaches it at 0.4s. Timing:
+# the signal fires on the second frame glyph, never on a clock. A fixed 0.2s
+# turned a conforming kit red with a zero-byte capture, and a fixed 2.0s
+# produced a capture identical to an uninterrupted run.
+@test "sigint: Ctrl-C during an apply leaves the cursor visible" {
+	local kit="$BATS_TEST_TMPDIR/sh-ui.sh" g
+	ui_render_kit "$kit"
+	g="$(ui_glyphs "$kit")"
+
+	local v="$BATS_TEST_TMPDIR/sig"
+	ui_apply_venue "$v" "$(ui_probe_body 40)"
+	ui_apply "$v" --glyphs "$g" --sigint-after-glyphs 2 --stdout "$v/out" \
+		--stderr "$v/err" --tty-capture "$v/tty" --timeout 90 || true
+
+	# One: the kit really ran and animated across a full frame interval. A
+	# purely negative reading passes on a zero-byte capture from a run that
+	# silently never executed.
+	[ "$(ui_shape "$v/tty" "$g" glyphs)" -ge 2 ]
+	# Two: nothing left the terminal without a cursor.
+	[ "$(ui_shape "$v/tty" "$g" unmatched_hide)" -eq 0 ]
+	# Three, the rule that actually discriminates. With two frames in the
+	# capture a per-frame-restore kit holds every span at 1 whatever happens
+	# after the signal, while a hide-once kit's opening hide spans both.
+	[ "$(ui_shape "$v/tty" "$g" max_span)" -le 1 ]
+
+	# The clause's own failing example, run through the same harness: a kit
+	# that hides once before its first frame and restores once after its last.
+	# A rule that cannot fail against it has not been verified, only assumed.
+	local w="$BATS_TEST_TMPDIR/sig-hide-once"
+	ui_apply_venue "$w" "$(ui_probe_body 40)"
+	ui_hide_once_kit "$kit" "$w/src/.chezmoitemplates/sh-ui.sh"
+	ui_apply "$w" --glyphs "$g" --sigint-after-glyphs 2 --stdout "$w/out" \
+		--stderr "$w/err" --tty-capture "$w/tty" --timeout 90 || true
+	[ "$(ui_shape "$w/tty" "$g" max_span)" -ge 2 ]
+}

--- a/tests/progress.bats
+++ b/tests/progress.bats
@@ -386,3 +386,68 @@ EOF
 		return 1
 	}
 }
+
+# ---- C-13: no frame lands on the stream brew's password prompt uses --------
+
+# Two observations of the rendered installer, with fd 1 captured separately
+# from /dev/tty because the property is about one of those streams and an
+# assertion on the other cannot see it.
+#
+# Both bundle invocations count, and the run that reaches the second one is not
+# optional. A harness running only the happy path reports zero violations
+# against a script that animates across the retry and calls that a pass, so a
+# run in which the retry interval was never entered is a failed check rather
+# than a passed one.
+@test "tty-scope: no frame lands inside either brew bundle invocation" {
+	local kit="$BATS_TEST_TMPDIR/sh-ui.sh" root="$BATS_TEST_TMPDIR/pkg" g
+	ui_render_kit "$kit"
+	g="$(ui_glyphs "$kit")"
+	mkdir -p "$root"
+
+	local names keep drop
+	names="$(ui_brewfile_names)"
+	keep="$(printf '%s\n' "$names" | sed -n 1p)"
+	drop="$(printf '%s\n' "$names" | sed -n 2p)"
+	[ -n "$keep" ]
+	[ -n "$drop" ]
+
+	# One bundle, exiting clean.
+	local v
+	v="$(ui_ten_venue "$root/plain" run_onchange_install-packages.sh.tmpl)"
+	ui_write_brew_bundle_stub "$v" plain "$drop" "$keep"
+	ui_run_ten "$v" --glyphs "$g" --stdout "$v/out" --stderr "$v/err" \
+		--tty-capture "$v/tty" --timeout 120 || true
+	[ "$(ui_intervals "$v/tty" "$g" intervals)" -ge 1 ]
+	[ "$(ui_intervals "$v/tty" "$g" violations)" -eq 0 ]
+
+	# The settled line follows brew's last line rather than preceding it.
+	local brew_line settled_line
+	brew_line="$(grep -n 'Homebrew Bundle complete' "$v/out" | tail -1 | cut -d: -f1)"
+	settled_line="$(grep -n '^  [✓!✗]  packages' "$v/out" | tail -1 | cut -d: -f1)"
+	[ -n "$brew_line" ]
+	[ -n "$settled_line" ]
+	[ "$settled_line" -gt "$brew_line" ]
+
+	# Two bundles, the second reached through the drop-and-retry path.
+	local w
+	w="$(ui_ten_venue "$root/retry" run_onchange_install-packages.sh.tmpl)"
+	ui_write_brew_bundle_stub "$w" retry "$drop" "$keep"
+	ui_run_ten "$w" --glyphs "$g" --stdout "$w/out" --stderr "$w/err" \
+		--tty-capture "$w/tty" --timeout 120 || true
+	[ "$(wc -l <"$w/bundle-calls.log" | tr -d ' ')" -eq 2 ]
+	[ "$(ui_intervals "$w/tty" "$g" intervals)" -eq 2 ]
+	[ "$(ui_intervals "$w/tty" "$g" violations)" -eq 0 ]
+
+	# The clause's own failing example through the same harness. Without this
+	# the check has been assumed rather than verified, and the stub's dwell is
+	# what gives a frame room to land: the same violating script measured clean
+	# against an instant stub and dirty against one holding the interval open.
+	local b
+	b="$(ui_ten_venue "$root/bad" run_onchange_install-packages.sh.tmpl)"
+	ui_write_brew_bundle_stub "$b" plain "$drop" "$keep"
+	ui_animate_over_bundle "$b/script.sh"
+	ui_run_ten "$b" --glyphs "$g" --stdout "$b/out" --stderr "$b/err" \
+		--tty-capture "$b/tty" --timeout 120 || true
+	[ "$(ui_intervals "$b/tty" "$g" intervals)" -ge 1 ]
+	[ "$(ui_intervals "$b/tty" "$g" violations)" -gt 0 ]
+}

--- a/tests/progress.bats
+++ b/tests/progress.bats
@@ -113,3 +113,64 @@ setup() {
 	tail="$(LC_ALL=C tail -c 12 "$d/m1.tty" | od -An -c | tr -s ' ')"
 	assert_contains "\\r 033 [ K 033 [ ? 2 5 h" "$tail"
 }
+
+# ---- C-1: the detector asks whether a human is watching --------------------
+
+# The venue is redirected-but-watched, and no other venue answers. Under a bare
+# pty apply, and under setsid, `[ -t 1 ]`, `[ -t 2 ]`, and a /dev/tty open all
+# agree, so a case run in either of those goes green against the exact
+# detectors this forbids. Pinning fd 2 as well as fd 1 is what stops a
+# relocation of the original bug to `[ -t 2 ]` from passing.
+@test "detector: animation follows the terminal, not whether stdout is a tty" {
+	local kit="$BATS_TEST_TMPDIR/sh-ui.sh"
+	ui_render_kit "$kit"
+
+	# No `-t 1` survives in executable code. A comment recording the removal
+	# is not a violation, so comment lines come out first. This assertion
+	# lives here because the clause gets exactly one case, and one homed
+	# anywhere else is homed nowhere.
+	[ "$(grep -vE '^[[:space:]]*#' "$kit" | grep -cE '\-t 1')" -eq 0 ]
+
+	local v="$BATS_TEST_TMPDIR/watched"
+	ui_apply_venue "$v" "$(ui_probe_body)"
+	local g
+	g="$(ui_glyphs "$kit")"
+
+	# Watched: fd 1 and fd 2 are both files, and /dev/tty is still open. A
+	# human piping or capturing an apply is standing right here.
+	ui_apply "$v" --glyphs "$g" --stdout "$v/out" --stderr "$v/err" \
+		--tty-capture "$v/tty" --timeout 90
+	[ "$(ui_distinct_glyphs "$v/tty" "$g")" -ge 1 ]
+	[ "$(ui_esc_count "$v/out")" -eq 0 ]
+
+	# Blind: no controlling terminal, so plain lines and nothing else.
+	local w="$BATS_TEST_TMPDIR/blind"
+	ui_apply_venue "$w" "$(ui_probe_body)"
+	ui_apply "$w" --setsid --stdout "$w/out" --stderr "$w/err" --timeout 90
+	[ "$(ui_esc_count "$w/out")" -eq 0 ]
+	[ "$(ui_distinct_glyphs "$w/out" "$g")" -eq 0 ]
+	[ "$(ui_count_matching '^  ✓  ' "$(cat "$w/out")")" -ge 1 ]
+}
+
+# ---- C-3: the animation actually animates under a pty ----------------------
+
+@test "animates: the frame advances rather than sitting on one glyph" {
+	local kit="$BATS_TEST_TMPDIR/sh-ui.sh"
+	ui_render_kit "$kit"
+	local v="$BATS_TEST_TMPDIR/anim" g
+	ui_apply_venue "$v" "$(ui_probe_body)"
+	g="$(ui_glyphs "$kit")"
+
+	# Redirecting the script's stdout is required, not tidiness: under a pty,
+	# /dev/tty and chezmoi's forwarded stdout are the same stream, and a
+	# combined capture cannot tell an animation on /dev/tty from one wrongly
+	# drawn to stdout.
+	ui_apply "$v" --glyphs "$g" --stdout "$v/out" --stderr "$v/err" \
+		--tty-capture "$v/tty" --timeout 90
+
+	[ "$(ui_distinct_glyphs "$v/tty" "$g")" -ge 2 ]
+	# Each frame opens by returning to column 0, so a capture carrying two
+	# distinct glyphs and fewer than two carriage returns has drawn them side
+	# by side instead of over each other.
+	[ "$(LC_ALL=C tr -cd '\r' <"$v/tty" | wc -c | tr -d ' ')" -ge 2 ]
+}

--- a/tests/progress.bats
+++ b/tests/progress.bats
@@ -174,6 +174,18 @@ setup() {
 	# by side instead of over each other.
 	[ "$(LC_ALL=C tr -cd '\r' <"$v/tty" | wc -c | tr -d ' ')" -ge 2 ]
 
+	# The frame has to advance while the caller is blocked, not only when it
+	# ticks. Every adopted script ticks once per item and then sits inside an
+	# install for seconds, so a kit that redraws only on step_tick shows one
+	# frozen glyph for the whole item. That is C-3's failing example reached
+	# through the path the ten scripts actually take, and the tick-in-a-loop
+	# fixture above cannot see it.
+	local b="$BATS_TEST_TMPDIR/blocking"
+	ui_apply_venue "$b" "$(ui_probe_body_blocking 3)"
+	ui_apply "$b" --glyphs "$g" --stdout "$b/out" --stderr "$b/err" \
+		--tty-capture "$b/tty" --timeout 90
+	[ "$(ui_distinct_glyphs "$b/tty" "$g")" -ge 2 ]
+
 	# The same live line on a narrow terminal. A wrapped line sends the next
 	# carriage return back to the wrong row, and the animation starts eating
 	# the scrollback above it.

--- a/tests/progress.bats
+++ b/tests/progress.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+#
+# The display kit's own suite (GitHub #16). Ten cases, one per constitution
+# clause that names a filter, each named so `--filter "^<token>:"` selects
+# exactly one:
+#
+#   detector  stdout  animates  adoption  failure
+#   sigint    fail-open  bash32  tty-scope  setsid-log
+#
+# The anchor is not decoration. `bats --filter` matches a regex against test
+# NAMES, so a bare token is satisfied by any name containing it—an
+# unanchored "stdout" selects three of these, because `detector`'s name ends
+# "whether stdout is a tty" and `setsid-log`'s contains "write no ESC to
+# stdout". Keep every token's own name unique under its anchor.
+#
+# Assertions are single-bracket or helper calls throughout, never a bare
+# `[[ ]]`. Bash 3.2 does not abort on a failing `[[ ]]` under errexit unless
+# it is the body's literal last statement, so the idiom a worker reaches for
+# first—`[[ "$output" == *" ✓ "* ]]`—reports `ok` against a kit that
+# defines no helpers at all. tests/lint.bats is what stops one coming back.
+
+load 'helpers'
+
+setup() {
+	# Both are set on this machine, and a script honoring them goes straight
+	# back to the real ~/.config and ~/.cache no matter what $HOME says.
+	unset XDG_CONFIG_HOME
+	unset XDG_CACHE_HOME
+	mkdir -p "$BATS_TEST_TMPDIR/dest"
+}
+
+# ---- C-11: the kit runs under bash 3.2 at runtime, not just at parse time ---
+
+# Asserts on what the helpers PRODUCE, never on the exit status of a script
+# that calls them. Under `set -u` alone a missing helper is a non-fatal
+# command-not-found, so a status-only case goes green against a kit defining
+# none of the six—and the ten scripts share no shell regime (six set -e, one
+# -uo pipefail, three nothing), so this cannot lean on errexit either.
+@test "bash32: every helper runs and produces its line under /bin/bash 3.2" {
+	local kit="$BATS_TEST_TMPDIR/sh-ui.sh"
+	ui_render_kit "$kit"
+
+	# set -eu is the strictest regime any caller imposes, and it is where
+	# bash 3.2's unset-array trap lives: `${#a[@]}` raises `unbound variable`
+	# when a is unset and evaluates to 0 when it is merely empty.
+	run env -u NO_COLOR -u DOTFILES_NO_PROGRESS /bin/bash -c "
+		set -eu
+		. '$kit'
+		ui_watching || true
+		step_begin 'unit test'
+		step_ok    'alpha'   'first detail'
+		step_warn  'bravo'   'second detail'
+		step_fail  'charlie' 'third detail'
+		ui_finalize 0
+	"
+
+	[ "$status" -eq 0 ]
+	# The settled-line shape C-4 requires: two spaces, one glyph, two spaces.
+	[ "$(ui_count_matching '^  ✓  ')" -ge 1 ]
+	[ "$(ui_count_matching '^  !  ')" -ge 1 ]
+	[ "$(ui_count_matching '^  ✗  ')" -ge 1 ]
+	assert_contains "alpha"
+	assert_contains "bravo"
+	assert_contains "charlie"
+}
+
+# ---- C-2: the bytes the kit writes to stdout carry no escape codes ---------
+
+# Three modes, because the kit fails differently in each. The third is not
+# hypothetical. It is C-7's first injection, and a straightforward kit fails it
+# because bash 3.2 holds the bytes of a failed `printf … >&9` in its stdout
+# buffer and flushes them to fd 1 when the redirection is undone.
+@test "stdout: no ESC reaches fd 1 whether the tty is writable, absent, or broken" {
+	local kit="$BATS_TEST_TMPDIR/sh-ui.sh" fx="$BATS_TEST_TMPDIR/fixture.sh"
+	ui_render_kit "$kit"
+	ui_write_animating_fixture "$fx" "$kit"
+	local g
+	g="$(ui_glyphs "$kit")"
+	local d="$BATS_TEST_TMPDIR"
+
+	# Mode 1—/dev/tty open and writable, fd 1 captured separately from it.
+	# The separation is the whole measurement: under a pty, /dev/tty and a
+	# forwarded stdout are the same stream.
+	ui_pty --glyphs "$g" --stdout "$d/m1.out" --stderr "$d/m1.err" \
+		--tty-capture "$d/m1.tty" --timeout 60 -- /bin/bash "$fx"
+	[ "$(ui_esc_count "$d/m1.out")" -eq 0 ]
+	# Not vacuous: the run really did animate, so fd 1 stayed clean while
+	# escape codes were being written somewhere.
+	[ "$(ui_esc_count "$d/m1.tty")" -gt 0 ]
+	[ ! -s "$d/m1.err" ]
+
+	# Mode 2—detached, no controlling terminal. The degradation contract:
+	# plain lines, and no complaint about the terminal that isn't there.
+	ui_pty --setsid --stdout "$d/m2.out" --stderr "$d/m2.err" --timeout 60 \
+		-- /bin/bash "$fx"
+	[ "$(ui_esc_count "$d/m2.out")" -eq 0 ]
+	[ "$(ui_count_matching '^  ✓  ' "$(cat "$d/m2.out")")" -ge 1 ]
+	assert_not_contains "/dev/tty" "$(cat "$d/m2.err")"
+
+	# Mode 3—/dev/tty open but its writes failing, built by closing the pty
+	# master mid-animation. The fixture carries `trap '' HUP` or it dies at
+	# 129 before it can spill anything.
+	ui_pty --glyphs "$g" --close-master-after-glyphs 2 --stdout "$d/m3.out" \
+		--stderr "$d/m3.err" --tty-capture "$d/m3.tty" --timeout 60 \
+		-- /bin/bash "$fx"
+	[ "$(ui_esc_count "$d/m3.out")" -eq 0 ]
+
+	# The erase, judged from the /dev/tty capture alone so the property needs
+	# no interleaving of two separately captured streams: after the final
+	# frame, nothing but the cursor restore, and no residual frame text
+	# trailing the erase.
+	local tail
+	tail="$(LC_ALL=C tail -c 12 "$d/m1.tty" | od -An -c | tr -s ' ')"
+	assert_contains "\\r 033 [ K 033 [ ? 2 5 h" "$tail"
+}

--- a/tests/support/bundle-intervals.py
+++ b/tests/support/bundle-intervals.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Report frame glyphs landing inside a brew bundle's own interval.
+
+The property is interval-scoped, not whole-run silence, and the difference
+decides real cases. Read as whole-run silence the rule rejects a script that
+animates around the tap-trust loop; read as interval silence it permits that
+and still catches the frame that matters. The interval is the reading.
+
+The stub standing in for `brew bundle` brackets itself by writing BUNDLE-ENTER
+and BUNDLE-EXIT markers to /dev/tty, so entry and exit are anchored by the
+thing being measured rather than guessed from timing. A frame glyph between an
+ENTER and its matching EXIT is a violation, because that is the window in which
+a cask's sudo prompt owns the stream.
+
+Usage: bundle-intervals.py CAPTURE GLYPHS
+Prints: intervals=N violations=M
+"""
+
+import re
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.stderr.write("usage: bundle-intervals.py CAPTURE GLYPHS\n")
+        return 2
+    data = open(sys.argv[1], "rb").read()
+    glyphs = [g.encode("utf-8") for g in sys.argv[2]]
+
+    intervals = 0
+    violations = 0
+    for m in re.finditer(rb"BUNDLE-ENTER-(\d+)", data):
+        n = m.group(1)
+        exit_m = re.search(rb"BUNDLE-EXIT-" + n, data[m.end():])
+        if exit_m is None:
+            # An interval opened and never closed still counts as entered, and
+            # everything after it is inside it.
+            segment = data[m.end():]
+        else:
+            segment = data[m.end():m.end() + exit_m.start()]
+        intervals += 1
+        violations += sum(segment.count(g) for g in glyphs)
+
+    print("intervals=%d violations=%d" % (intervals, violations))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/support/capture-shape.py
+++ b/tests/support/capture-shape.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Report the cursor-hygiene shape of a /dev/tty capture.
+
+Three numbers, because the interesting property is not "was the cursor visible
+afterward". That question was measured unable to discriminate: the same kit won
+the post-signal race 11 trials of 12 in one harness, lost 12 of 12 in another,
+and won 5 of 6 standalone, so the ending describes the venue rather than the
+kit. What survives every venue is the shape of the byte stream.
+
+  glyphs          how many frame glyphs the capture carries. A capture with
+                  fewer than two proves nothing: a purely negative reading
+                  passes on a zero-byte capture from a run that never executed.
+
+  unmatched_hide  1 when an ESC[?25l is never followed by its restore, so the
+                  terminal is left with no cursor.
+
+  max_span        the most frame glyphs lying between any ESC[?25l and its
+                  matching restore, with an unmatched hide running to the end
+                  of the capture. A kit that restores on every frame write is
+                  bounded at 1 by construction. A kit that hides once and
+                  restores once spans every frame it drew.
+
+Usage: capture-shape.py CAPTURE GLYPHS
+"""
+
+import re
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.stderr.write("usage: capture-shape.py CAPTURE GLYPHS\n")
+        return 2
+    data = open(sys.argv[1], "rb").read()
+    glyphs = [g.encode("utf-8") for g in sys.argv[2]]
+
+    def count(buf):
+        return sum(buf.count(g) for g in glyphs)
+
+    unmatched = 0
+    max_span = 0
+    for m in re.finditer(rb"\x1b\[\?25l", data):
+        end = data.find(b"\x1b[?25h", m.end())
+        if end == -1:
+            unmatched = 1
+            segment = data[m.end():]
+        else:
+            segment = data[m.end():end]
+        max_span = max(max_span, count(segment))
+
+    print("glyphs=%d unmatched_hide=%d max_span=%d" % (count(data), unmatched, max_span))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/support/line-width.py
+++ b/tests/support/line-width.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Widest live line in a /dev/tty capture, in display columns.
+
+Columns, not bytes. Every live line carries multibyte glyphs and CSI
+sequences, so a raw byte count passes 40 long before the line has rendered
+anything, and a check built on it fails a conforming kit.
+
+A line that wraps is worse than a line that is merely long: the next carriage
+return goes back to the wrong row and the animation starts eating the
+scrollback above it.
+
+Records are split on carriage returns, since every frame opens by returning to
+column 0. CSI sequences count as zero. Braille and block glyphs count as the
+one column each renders as, which is what Python's len() over decoded text
+already gives.
+
+Usage: line-width.py CAPTURE
+"""
+
+import re
+import sys
+
+CSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: line-width.py CAPTURE\n")
+        return 2
+    text = open(sys.argv[1], "rb").read().decode("utf-8", "replace")
+    widest = 0
+    for record in re.split(r"[\r\n]", text):
+        widest = max(widest, len(CSI.sub("", record)))
+    print(widest)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/support/pty-run.py
+++ b/tests/support/pty-run.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Run a command under a controlled terminal situation and capture the streams apart.
+
+The whole progress kit turns on which stream a byte lands on, so a harness that
+cannot separate them cannot see the property. Under a pty, /dev/tty and a
+forwarded stdout are the same stream: a combined capture cannot tell an
+animation drawn on /dev/tty from one wrongly drawn to stdout. So the child gets
+fd 1 and fd 2 on real files while its controlling terminal stays the pty, and
+what comes back off the master is the /dev/tty stream and nothing else.
+
+Modes, and the measurement behind each:
+
+  (default)   pty with a controlling terminal. fd 0 comes from /dev/null, not
+              from the pty: run_once_before_install-prerequisites.sh.tmpl:111
+              reads a reply gated on `[ -t 0 ]`, and pty.fork() hands the child
+              the pty, so the run sits at "Install them now? [Y/n]" forever.
+  --setsid    no controlling terminal at all, so /dev/tty fails to open. This is
+              the degradation contract's venue: ssh without a tty, a cron job.
+              A captured apply is deliberately NOT this venue—its /dev/tty
+              stays open, which is why a capture discriminates detectors instead.
+  --cols N    pty winsize. Live lines are judged for wrapping at 40 columns, and
+              only `stty size </dev/tty` can answer there: no script under
+              `chezmoi apply` has COLUMNS set or TERM exported.
+
+Every run is bounded. This tree has two ways to hang for an hour: an unanswered
+prompt at install-prerequisites:111, and a spin_until at :99 waiting on Command
+Line Tools that no harness can install. A run that hits the bound exits 199,
+which is loud and never mistakable for a command's own status.
+"""
+
+import argparse
+import errno
+import fcntl
+import os
+import pty
+import selectors
+import signal
+import struct
+import sys
+import termios
+
+EXIT_TIMEOUT = 199  # distinct and loud: never mistakable for a command's own status
+CTTY_KEEPALIVE_FD = 20  # high enough that no shell under test reaches for it
+
+
+def set_winsize(fd, rows, cols):
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--stdout", required=True, help="file to receive the child's fd 1")
+    ap.add_argument("--stderr", required=True, help="file to receive the child's fd 2")
+    ap.add_argument("--tty-capture", help="file to receive the pty master stream")
+    ap.add_argument("--setsid", action="store_true", help="no controlling terminal")
+    ap.add_argument("--cols", type=int, default=80)
+    ap.add_argument("--rows", type=int, default=24)
+    ap.add_argument("--timeout", type=float, default=120.0)
+    ap.add_argument("--cwd")
+    ap.add_argument(
+        "--glyphs",
+        default="",
+        help="frame glyphs to count in the master stream, as one string",
+    )
+    ap.add_argument(
+        "--close-master-after-glyphs",
+        type=int,
+        default=0,
+        help="close the pty master once this many frame glyphs have appeared, "
+        "making /dev/tty present-but-unwritable",
+    )
+    ap.add_argument(
+        "--sigint-after-glyphs",
+        type=int,
+        default=0,
+        help="SIGINT the child's process group once this many frame glyphs have "
+        "appeared; anchor the signal on an event, never on a wall clock",
+    )
+    ap.add_argument("cmd", nargs=argparse.REMAINDER)
+    args = ap.parse_args()
+
+    argv = args.cmd[1:] if args.cmd and args.cmd[0] == "--" else args.cmd
+    if not argv:
+        sys.stderr.write("pty-run: no command given\n")
+        return 2
+
+    if args.setsid:
+        return run_setsid(args, argv)
+    return run_pty(args, argv)
+
+
+def child_exec(args, argv):
+    """Common child-side setup: fd 0 from /dev/null, fd 1 and fd 2 to real files."""
+    devnull = os.open(os.devnull, os.O_RDONLY)
+    os.dup2(devnull, 0)
+    out = os.open(args.stdout, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    err = os.open(args.stderr, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    os.dup2(out, 1)
+    os.dup2(err, 2)
+    for fd in (devnull, out, err):
+        if fd > 2:
+            os.close(fd)
+    if args.cwd:
+        os.chdir(args.cwd)
+    os.execvp(argv[0], argv)
+
+
+def run_setsid(args, argv):
+    pid = os.fork()
+    if pid == 0:
+        os.setsid()  # the form the constitution measured; drops the controlling terminal
+        try:
+            child_exec(args, argv)
+        except Exception as exc:  # pragma: no cover - exec failure path
+            sys.stderr.write("pty-run: exec failed: %s\n" % exc)
+            os._exit(127)
+    return reap(pid, args.timeout)
+
+
+def run_pty(args, argv):
+    master, slave = pty.openpty()
+    set_winsize(slave, args.rows, args.cols)
+
+    pid = os.fork()
+    if pid == 0:
+        os.close(master)
+        os.setsid()
+        fcntl.ioctl(slave, termios.TIOCSCTTY, 0)  # this pty becomes /dev/tty
+        # Park the slave on a high fd and leave it open for the child's whole
+        # life. On BSD the last close of a controlling terminal revokes it, so
+        # a child that closes its slave finds /dev/tty answering
+        # "Device not configured"—the venue this mode exists to rule out.
+        # fd 1 and 2 still go to real files below, which is the separation the
+        # measurement needs; an extra fd nobody reads changes nothing else.
+        os.dup2(slave, CTTY_KEEPALIVE_FD)
+        if slave != CTTY_KEEPALIVE_FD:
+            os.close(slave)
+        try:
+            child_exec(args, argv)
+        except Exception as exc:  # pragma: no cover - exec failure path
+            sys.stderr.write("pty-run: exec failed: %s\n" % exc)
+            os._exit(127)
+
+    os.close(slave)
+    return pump(master, pid, args)
+
+
+def count_glyphs(buf, glyphs):
+    """How many frame glyphs the master stream has carried so far.
+
+    Counted over the accumulated buffer rather than per chunk, because a
+    multi-byte glyph can straddle a read boundary and a per-chunk count would
+    lose it exactly when the animation is fastest.
+    """
+    return sum(buf.count(g.encode("utf-8")) for g in glyphs)
+
+
+def pump(master, pid, args):
+    """Drain the master into --tty-capture until the child exits or time runs out.
+
+    Two triggers can fire off this stream, and both are anchored on frames
+    rather than on a wall clock. Timing by clock forks the result: a
+    conforming kit measured red at 0.2s (a zero-byte capture from a run that
+    had not started) and green at 2.0s (a capture identical to an
+    uninterrupted run). The event is the only stable anchor.
+    """
+    sink = open(args.tty_capture, "wb", buffering=0) if args.tty_capture else None
+    seen = bytearray()
+    glyphs = list(args.glyphs)
+    fired_close = False
+    fired_sigint = False
+    sel = selectors.DefaultSelector()
+    sel.register(master, selectors.EVENT_READ)
+    deadline = monotonic_deadline(args.timeout)
+    status = None
+
+    try:
+        while True:
+            remaining = deadline - now()
+            if remaining <= 0:
+                kill(pid)
+                sys.stderr.write("pty-run: TIMEOUT after %.1fs\n" % args.timeout)
+                return EXIT_TIMEOUT
+            for _key, _mask in sel.select(timeout=min(remaining, 0.2)):
+                try:
+                    chunk = os.read(master, 65536)
+                except OSError as exc:
+                    if exc.errno in (errno.EIO, errno.EBADF):
+                        chunk = b""
+                    else:
+                        raise
+                if not chunk:
+                    sel.unregister(master)
+                    break
+                if sink:
+                    sink.write(chunk)
+                if glyphs:
+                    seen.extend(chunk)
+                    n = count_glyphs(seen, glyphs)
+                    if (
+                        args.sigint_after_glyphs
+                        and not fired_sigint
+                        and n >= args.sigint_after_glyphs
+                    ):
+                        fired_sigint = True
+                        try:
+                            os.killpg(os.getpgid(pid), signal.SIGINT)
+                        except OSError:
+                            pass
+                    if (
+                        args.close_master_after_glyphs
+                        and not fired_close
+                        and n >= args.close_master_after_glyphs
+                    ):
+                        fired_close = True
+                        # Closing the master is the only way to make /dev/tty
+                        # present-but-unwritable. It SIGHUPs the whole
+                        # foreground group, so the script under test has to
+                        # carry `trap "" HUP` or it dies at 129 before it can
+                        # spill anything.
+                        sel.unregister(master)
+                        os.close(master)
+                        master = -1
+                        break
+            if master == -1:
+                status = reap(pid, max(deadline - now(), 0.1))
+                return status
+            if status is None:
+                done, code = try_reap(pid)
+                if done:
+                    status = code
+                    # One more non-blocking drain: the child's last frames may
+                    # still be sitting in the pty buffer after it exits.
+                    drain(master, sink)
+                    return status
+    finally:
+        if sink:
+            sink.close()
+        if master != -1:
+            try:
+                os.close(master)
+            except OSError:
+                pass
+
+
+def drain(master, sink):
+    fl = fcntl.fcntl(master, fcntl.F_GETFL)
+    fcntl.fcntl(master, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+    while True:
+        try:
+            chunk = os.read(master, 65536)
+        except (OSError, BlockingIOError):
+            return
+        if not chunk:
+            return
+        if sink:
+            sink.write(chunk)
+
+
+def try_reap(pid):
+    wpid, status = os.waitpid(pid, os.WNOHANG)
+    if wpid == 0:
+        return False, None
+    return True, exit_code(status)
+
+
+def reap(pid, timeout):
+    deadline = monotonic_deadline(timeout)
+    while now() < deadline:
+        wpid, status = os.waitpid(pid, os.WNOHANG)
+        if wpid != 0:
+            return exit_code(status)
+        sleep(0.02)
+    kill(pid)
+    sys.stderr.write("pty-run: TIMEOUT after %.1fs\n" % timeout)
+    return EXIT_TIMEOUT
+
+
+def exit_code(status):
+    if os.WIFSIGNALED(status):
+        return 128 + os.WTERMSIG(status)
+    return os.WEXITSTATUS(status)
+
+
+def kill(pid):
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(os.getpgid(pid), sig)
+        except OSError:
+            try:
+                os.kill(pid, sig)
+            except OSError:
+                return
+        sleep(0.1)
+        try:
+            if os.waitpid(pid, os.WNOHANG)[0] != 0:
+                return
+        except OSError:
+            return
+
+
+def now():
+    import time
+
+    return time.monotonic()
+
+
+def monotonic_deadline(timeout):
+    return now() + timeout
+
+
+def sleep(seconds):
+    import time
+
+    time.sleep(seconds)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/support/pty-run.py
+++ b/tests/support/pty-run.py
@@ -47,6 +47,30 @@ def set_winsize(fd, rows, cols):
     fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
 
 
+class Timeout(Exception):
+    pass
+
+
+def arm_hard_timeout(seconds):
+    """Bound the run with SIGALRM, independent of the drain loop.
+
+    The loop below checks a deadline of its own on every iteration, and that
+    check is the one that produces a clean kill and a readable message. This is
+    the backstop for the case where the loop is not iterating: a real
+    `chezmoi apply` overran a 1500-second bound by eleven minutes and the
+    in-loop check never fired, on a run that could not be reproduced in
+    isolation afterward. A bound that only works when the code around it is
+    correct is not a bound, and this harness exists to keep a hung check from
+    looking like a slow one.
+    """
+
+    def fire(_signum, _frame):
+        raise Timeout()
+
+    signal.signal(signal.SIGALRM, fire)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--stdout", required=True, help="file to receive the child's fd 1")
@@ -84,9 +108,22 @@ def main():
         sys.stderr.write("pty-run: no command given\n")
         return 2
 
-    if args.setsid:
-        return run_setsid(args, argv)
-    return run_pty(args, argv)
+    # Armed with a margin over the in-loop deadline, so a healthy run still
+    # reports its own timeout with the message and the clean process-group kill
+    # that go with it. This only speaks when that path did not.
+    arm_hard_timeout(args.timeout + 30)
+    try:
+        if args.setsid:
+            return run_setsid(args, argv)
+        return run_pty(args, argv)
+    except Timeout:
+        sys.stderr.write(
+            "pty-run: HARD TIMEOUT after %.1fs (in-loop deadline never fired)\n"
+            % (args.timeout + 30)
+        )
+        return EXIT_TIMEOUT
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
 
 
 def child_exec(args, argv):


### PR DESCRIPTION
`chezmoi apply` read as nine unrelated tools rather than one run, going silent for minutes at a stretch on the runs that actually do work: a new machine, a changed script, a brew day. This moves the shared display kit onto `/dev/tty`, gives it a step vocabulary, and adopts it across all ten templated `run_` scripts, so an apply leaves one column of settled lines behind a single live line.

The issue's founding diagnosis was wrong and this PR does not fix what it describes. The tty detector was never broken: the original probe read `[ -t 1 ]` inside a command substitution, where fd 1 is the substitution's pipe, so it reported no terminal on every terminal. Measured directly, an attended apply hands scripts a tty on stdout, stderr, and stdin. The real defects were coverage (eight of the ten scripts printed raw tool output or nothing), cursor hygiene (the kit hid the cursor to animate and died without restoring it), and channel (animation on stdout leaked escape codes into any captured apply while going plain for a watching human whose stdout was piped).

Splitting the channel is what fixes the last two at once. Animation goes to a descriptor opened on `/dev/tty` and settled lines go to stdout, so a piped or captured apply still animates for the human while its log stays greppable.

## Testing

`bats tests/` passes at 194 cases, zero failures, zero skips, up from the 184 this branch started at.

Passing tests prove less than usual here, because the suite is new and could be measuring itself. So there is a second check: restore `.chezmoitemplates/sh-ui.sh` and the ten scripts to `bcd84a7`, keep `tests/` as built, and confirm all ten filters go red. They do, one case each. A filter that cannot fail against the kit as the job found it is not observing the kit.

An attended `chezmoi apply >log 2>&1` ran end to end on one machine: animation on the terminal throughout, cursor restored at the end, and zero ESC bytes in the capture. `HANDOVER.md` carries that command for anyone repeating it.

What is not tested: the ten scripts under real `brew`, `code`, `op`, and `npm`. Every automated venue stubs them by effect, deliberately, because the alternative reaches live package state and the user's 1Password. The attended run above is the only time these scripts drove real tools, and it was one machine and one pass.

## Where to start reading

`.chezmoitemplates/sh-ui.sh` is the change. `tests/progress.bats` is ten cases, one per property, each named for the filter that selects it. The four files under `tests/support/` are new instruments rather than logic: a pty driver and three analyzers for capture shape, line width, and brew-interval attribution.

Two findings came from watching a real apply and could not have come from the suite. The frame rode entirely on `step_tick`, which every script calls once per item before blocking inside an install for seconds, so the glyph froze for exactly as long as the work took. The test fixture ticked in a tight loop and could not see it. And at 1 Hz the spinner read as stalled, because the terminal's cursor blinks at about that rate and is the reference motion already on screen.

The ticker is the part I would review hardest. It is a background process per step, and it is the newest code here. It dies with the foreground process group on Ctrl-C and every frame write ends with the cursor restore, so an interrupt cannot strand a hidden cursor, but it has had far less exercise than the rest.

The installer deliberately gets a settled line and no live one, through a separate `step_begin_quiet` entry point. A frame drawn while `brew bundle` holds `/dev/tty` can erase a cask's `sudo` prompt and hang the apply on something shown for 100ms. Making it a different function keeps that structural rather than a matter of where frames happen to land.

Left out on purpose: brew's live fetch display is #33, and `run_once_after_configure-macos.sh` stays unconverted because any content edit changes its `contentsSHA256` and re-runs a `killall` script on every machine.

Closes #16
